### PR TITLE
Fix issue that resulted in only the first query parameter being kept after SSO

### DIFF
--- a/frontend/platform/URLRouter.ts
+++ b/frontend/platform/URLRouter.ts
@@ -16,7 +16,7 @@ export class URLRouter extends BaseURLRouter<SegmentType> {
 
     createSSOCallbackURL(): string {
         // The URL of the iframe's parent.
-        return parent.location.href;
+        return encodeURIComponent(parent.location.href);
     }
 
     normalizeUrl(): void {

--- a/frontend/platform/URLRouter.ts
+++ b/frontend/platform/URLRouter.ts
@@ -15,6 +15,11 @@ export class URLRouter extends BaseURLRouter<SegmentType> {
     }
 
     createSSOCallbackURL(): string {
+        // TODO: Remove the call to encodeURIComponent() once https://github.com/vector-im/hydrogen-web/pull/911 has been merged,
+        //       and a new release has been issued which contains that PR.
+        //       Note that package.json hardcodes hydrogen's version, so it will need to be updated so that the new
+        //       version is used.
+
         // The URL of the iframe's parent.
         return encodeURIComponent(parent.location.href);
     }


### PR DESCRIPTION
Since the redirect URL is passed as  a query parameter (`${this._homeserver}/_matrix/client/r0/login/sso/redirect?redirectUrl=${returnURL}`), it must be URI-encoded.