### PR TITLE
Single-room mode

### DIFF
--- a/block/block.json
+++ b/block/block.json
@@ -11,6 +11,10 @@
     "defaultHomeserver": {
       "type": "string",
       "default": ""
+    },
+    "roomId": {
+      "type": "string",
+      "default": ""
     }
   },
   "supports": {

--- a/block/inspector.tsx
+++ b/block/inspector.tsx
@@ -7,7 +7,7 @@ export default function Inspector({ attributes, setAttributes }): WPElement {
     return (
         <InspectorControls>
             <PanelBody
-                title={__("Homeserver", "chatrix")}
+                title={__("Homeserver and room", "chatrix")}
                 initialOpen={true}
             >
                 <PanelRow>
@@ -17,7 +17,27 @@ export default function Inspector({ attributes, setAttributes }): WPElement {
                         onChange={(value) => setAttributes({ defaultHomeserver: value })}
                     />
                 </PanelRow>
+                <PanelRow>
+                    <TextControl
+                        label={__("Room id (optional)", "chatrix")}
+                        value={attributes.roomId}
+                        onChange={(value) => setAttributes({ roomId: value })}
+                        help={<RoomIdHelp/>}
+                    />
+                </PanelRow>
             </PanelBody>
         </InspectorControls>
+    );
+}
+
+function RoomIdHelp() {
+    return (
+        <>
+            <p>{__("When a room id is specified, the client will be in single-room mode.", "chatrix")}</p>
+            <p>{__("In this mode, the client opens directly in that room, with the user not having access to the screen that shows the list of rooms.", "chatrix")}</p>
+            <p>{__("The room must be public, so that the user can join without requiring an invitation.", "chatrix")}</p>
+            <p>{__("The room id must be the room's actual id, it must not be an alias.", "chatrix")}</p>
+            <p>{__("Example: !abc123:example.com", "chatrix")}</p>
+        </>
     );
 }

--- a/block/inspector.tsx
+++ b/block/inspector.tsx
@@ -7,7 +7,7 @@ export default function Inspector({ attributes, setAttributes }): WPElement {
     return (
         <InspectorControls>
             <PanelBody
-                title={__("Homeserver and room", "chatrix")}
+                title={__("Homeserver", "chatrix")}
                 initialOpen={true}
             >
                 <PanelRow>
@@ -17,6 +17,11 @@ export default function Inspector({ attributes, setAttributes }): WPElement {
                         onChange={(value) => setAttributes({ defaultHomeserver: value })}
                     />
                 </PanelRow>
+            </PanelBody>
+            <PanelBody
+                title={__("Room", "chatrix")}
+                initialOpen={false}
+            >
                 <PanelRow>
                     <TextControl
                         label={__("Room id (optional)", "chatrix")}

--- a/frontend/build/.env.development
+++ b/frontend/build/.env.development
@@ -1,1 +1,2 @@
 VITE_HOMESERVER="matrix.org"
+#VITE_ROOM_ID="!abc-123:example.com"

--- a/frontend/build/vite.d.ts
+++ b/frontend/build/vite.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
     readonly VITE_HOMESERVER: string
+    readonly VITE_ROOM_ID: string
 }
 
 interface ImportMeta {

--- a/frontend/config/ConfigFactory.ts
+++ b/frontend/config/ConfigFactory.ts
@@ -13,6 +13,7 @@ export class ConfigFactory {
 
         return {
             defaultHomeserver: getQueryParam("defaultHomeserver") ?? "",
+            roomId: getQueryParam("roomId") ?? "",
             themeManifests: [
                 new URL("assets/theme-chatrix.json", import.meta.url).href,
             ],

--- a/frontend/config/IConfig.ts
+++ b/frontend/config/IConfig.ts
@@ -23,4 +23,13 @@ export interface IConfig {
         // id of dark theme
         dark: string;
     };
+
+    /**
+     * When a roomId is set, client will be in single-room mode.
+     * In this mode, the client opens directly in that room, with the user not having access to the screen that shows the list of rooms.
+     * The room must be public, so that the user can automatically be added to it, without requiring an invitation.
+     * The roomId must be the room's actual id, it must not be an alias.
+     * Example: !abc123:example.org
+     */
+    roomId?: string;
 }

--- a/frontend/config/IConfig.ts
+++ b/frontend/config/IConfig.ts
@@ -27,9 +27,9 @@ export interface IConfig {
     /**
      * When a roomId is set, client will be in single-room mode.
      * In this mode, the client opens directly in that room, with the user not having access to the screen that shows the list of rooms.
-     * The room must be public, so that the user can automatically be added to it, without requiring an invitation.
+     * The room must be public, so that the user can join without requiring an invitation.
      * The roomId must be the room's actual id, it must not be an alias.
-     * Example: !abc123:example.org
+     * Example: !abc123:example.com
      */
     roomId?: string;
 }

--- a/frontend/platform/Platform.ts
+++ b/frontend/platform/Platform.ts
@@ -1,6 +1,7 @@
 import { SessionInfoStorage } from "hydrogen-web/src/matrix/sessioninfo/localstorage/SessionInfoStorage";
 import { SettingsStorage } from "hydrogen-web/src/platform/web/dom/SettingsStorage";
 import { Platform as BasePlatform } from "hydrogen-web/src/platform/web/Platform";
+import { IConfig } from "../config/IConfig";
 import { History } from "./History";
 import { Navigation } from "./Navigation";
 import { StorageFactory } from "./StorageFactory";
@@ -34,6 +35,10 @@ export class Platform extends BasePlatform {
 
     async init() {
         super.init();
+    }
+
+    get config(): IConfig {
+        return super.config;
     }
 
     openUrl(url) {

--- a/frontend/styles/theme/theme.css
+++ b/frontend/styles/theme/theme.css
@@ -1,7 +1,13 @@
 @import "hydrogen-web/src/platform/web/ui/css/themes/element/theme.css";
 
+/* TODO: The rules below should be extracted out of the theme as they are theme-agnostic. */
+
 /* Somehow the SessionView is off by 8px, the following rules fix that. */
 .SessionView {
     top: 0;
     left: 0;
+}
+/* Hide back button when in single-room mode. */
+.RootView.single-room-mode .RoomHeader .close-middle {
+    display: none !important;
 }

--- a/frontend/targets/parent.ts
+++ b/frontend/targets/parent.ts
@@ -9,6 +9,7 @@ export function parent(scriptId: string) {
 
     let config = {
         defaultHomeserver: env.VITE_HOMESERVER,
+        roomId: env.VITE_ROOM_ID,
     };
 
     const scriptElement = document.querySelector(`#${scriptId}`);

--- a/frontend/viewmodels/RootViewModel.ts
+++ b/frontend/viewmodels/RootViewModel.ts
@@ -113,6 +113,10 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
                 void this._showPicker();
             }
         } else if (sessionId) {
+            if (this.platform.config.roomId) {
+                this.navigation.push("room", this.platform.config.roomId);
+            }
+
             if (!this._sessionViewModel || this._sessionViewModel.id !== sessionId) {
                 // See _showLogin for where _pendingClient comes from.
                 if (this._pendingClient && this._pendingClient.sessionId === sessionId) {

--- a/frontend/viewmodels/RootViewModel.ts
+++ b/frontend/viewmodels/RootViewModel.ts
@@ -78,6 +78,10 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
         return this._error;
     }
 
+    public get singleRoomMode(): boolean {
+        return !!this.platform.config.roomId;
+    }
+
     public async start() {
         allSections().forEach((section: Section) => {
             // @ts-ignore

--- a/frontend/views/RootView.ts
+++ b/frontend/views/RootView.ts
@@ -19,7 +19,12 @@ export class RootView extends TemplateView<RootViewModel> {
     }
 
     render(t, vm: RootViewModel) {
-        return t.mapView(vm => vm.activeSection, (section: Section) => {
+        return t.div({
+            className: {
+                "RootView": true,
+                "single-room-mode": vm.singleRoomMode,
+            },
+        }, t.mapView(vm => vm.activeSection, (section: Section) => {
                 switch (section) {
                     case Section.Login:
                         return new LoginView(vm.loginViewModel);
@@ -46,6 +51,6 @@ export class RootView extends TemplateView<RootViewModel> {
                         throw new Error(`Unknown section: ${vm.activeSection}`);
                 }
             }
-        );
+        ));
     }
 }

--- a/src/Block/iframe.js
+++ b/src/Block/iframe.js
@@ -22,6 +22,7 @@ function automattic_chatrix_iframe_url(block_attributes) {
 	const queryParams = new URLSearchParams(window.location.search);
 	const iframeQueryParams = {
 		defaultHomeserver: block_attributes.defaultHomeserver,
+		roomId: block_attributes.roomId,
 	};
 
 	if (queryParams.has("loginToken")) {
@@ -30,7 +31,9 @@ function automattic_chatrix_iframe_url(block_attributes) {
 
 	const url = new URL(config.iframeUrl);
 	for (let key in iframeQueryParams) {
-		url.searchParams.append(key, iframeQueryParams[key]);
+		if (!!iframeQueryParams[key]) {
+			url.searchParams.append(key, iframeQueryParams[key]);
+		}
 	}
 
 	return url.toString();


### PR DESCRIPTION
Fixes #78

Allow configuring a `roomId`, which will put the client in a single-room mode. In this mode, the client opens directly in that room, with the user not having access to the screen that shows the list of rooms.

The room must be public, so that the user can join without requiring an invitation. The `roomId` must be the room's actual id, it must not be an alias.

----

<img width="1085" alt="Screenshot 2022-10-26 at 16 26 51" src="https://user-images.githubusercontent.com/550401/198068657-2eab45b7-7c24-4677-9920-23f75a9ff31f.png">
