### PR TITLE
Release v0.3.0

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,8 +35,5 @@ jobs:
       - name: Run eslint
         run: yarn lint
 
-      - name: Build block
-        run: yarn build:block
-
-      - name: Build popup
-        run: yarn build:popup
+      - name: Build
+        run: yarn build

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - Tested up to: 6.1
 - Requires PHP: 7.4
 - License: [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html)
-- Stable tag: 0.2.1
+- Stable tag: 0.3.0
 - GitHub Plugin URI: https://github.com/Automattic/chatrix
 
 Matrix client for WordPress.

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -45,5 +45,4 @@ rm -f chatrix.php-e README.md-e
 git add chatrix.php README.md
 
 git commit -m "Release v$VERSION"
-git tag "v$VERSION"
-git push --tags origin "$RELEASE_BRANCH"
+git push origin "$RELEASE_BRANCH"

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -44,5 +44,15 @@ sed -i"" -e "s/\(- Stable tag: \)\(.*\)/\1$VERSION/g" README.md
 rm -f chatrix.php-e README.md-e
 git add chatrix.php README.md
 
+git --no-pager diff --cached
+
+printf "\n\n"
+read -p "Would you like to commit and push the above diff to the $RELEASE_BRANCH branch? [y|n] " yn
+case $yn in
+	yes|y ) ;;
+	* )
+	  error "Exiting without committing."
+esac
+
 git commit -m "Release v$VERSION"
 git push origin "$RELEASE_BRANCH"

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -15,7 +15,7 @@ VERSION=$1
 RELEASE_BRANCH="release-$VERSION"
 
 CURRENT_BRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
-if [ "$CURRENT_BRANCH" != "main" ]; then
+if [[ "$CURRENT_BRANCH" != "main" ]] && [[ "$CURRENT_BRANCH" != "$RELEASE_BRANCH" ]]; then
   error "You must be on branch main"
 fi
 

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -12,15 +12,24 @@ if [ -z "$1" ]; then
 fi
 
 VERSION=$1
+RELEASE_BRANCH="release-$VERSION"
 
 CURRENT_BRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
 if [ "$CURRENT_BRANCH" != "main" ]; then
   error "You must be on branch main"
 fi
 
-git checkout main
+# Make sure we're up-to-date with origin.
 git fetch
 git pull --no-rebase origin main
+
+# Checkout or create branch for release.
+if [[ $(git branch --list "$RELEASE_BRANCH") ]]
+then
+  git checkout "$RELEASE_BRANCH"
+else
+  git checkout -b "$RELEASE_BRANCH"
+fi
 
 for file in package.json composer.json block/block.json
 do
@@ -37,4 +46,4 @@ git add chatrix.php README.md
 
 git commit -m "Release v$VERSION"
 git tag "v$VERSION"
-git push --tags origin main
+git push --tags origin "$RELEASE_BRANCH"

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -1,11 +1,22 @@
 set -e
 
+function error {
+  RED='\033[0;31m'
+  NONE='\033[0m'
+  printf "$RED$1$NONE\n"
+  exit 1
+}
+
 if [ -z "$1" ]; then
-    echo "Provide a new version, current version is $(jq '.version' package.json)"
-    exit 1
+    error "Provide a new version, current version is $(jq '.version' package.json)"
 fi
 
 VERSION=$1
+
+CURRENT_BRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
+if [ "$CURRENT_BRANCH" != "main" ]; then
+  error "You must be on branch main"
+fi
 
 git checkout main
 git fetch

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -20,7 +20,7 @@ fi
 
 git checkout main
 git fetch
-git pull origin main
+git pull --no-rebase origin main
 
 for file in package.json composer.json block/block.json
 do

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -33,7 +33,7 @@ sed -i"" -e "s/\(Version: \)\(.*\)/\1$VERSION/g" chatrix.php
 sed -i"" -e "s/\(\$version = '\)\(.*\)/\1$VERSION';/g" chatrix.php
 sed -i"" -e "s/\(- Stable tag: \)\(.*\)/\1$VERSION/g" README.md
 rm -f chatrix.php-e README.md-e
-git add chatrix.php
+git add chatrix.php README.md
 
 git commit -m "Release v$VERSION"
 git tag "v$VERSION"

--- a/block/block.json
+++ b/block/block.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "apiVersion": 2,
   "name": "automattic/chatrix",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "title": "Chatrix",
   "category": "embed",
   "icon": "format-chat",

--- a/chatrix.php
+++ b/chatrix.php
@@ -5,7 +5,7 @@
  * Author: Automattic
  * Author URI: https://automattic.com/
  * Plugin URI: https://github.com/Automattic/chatrix
- * Version: 0.2.1
+ * Version: 0.3.0
  */
 
 use function Automattic\Chatrix\Admin\main as adminMain;
@@ -22,7 +22,7 @@ function automattic_chatrix_version(): string {
 	}
 
 	// Do not edit this line, it's automatically set by bin/prepare-release.sh.
-	$version = '0.2.1';
+	$version = '0.3.0';
 
 	return $version;
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/chatrix",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "WordPress plugin to embed a Matrix client into WordPress pages.",
   "type": "wordpress-plugin",
   "license": "GPL",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatrix",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Embedded Matrix client for WordPress",
   "repository": "git@github.com:Automattic/chatrix.git",
   "author": "Automattic",


### PR DESCRIPTION
- Output errors in red
- Don't rebase when pulling
- Must also commit README.md
- Prepare release on a dedicated branch, instead of main
- Don't create a tag when preparing release
- Ask user if they want to push the release commit
- Use to level build script
- Allow using a pre-existing branch
- Release v0.3.0
