### PR TITLE
Release v0.2.2

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,9 +1,8 @@
-# Create a draft release when a tag is pushed
 name: Create a release
 
 on:
   # Allow manual trigger from the Actions tab:
-  # https://github.com/Automattic/chatrix/actions/workflows/release.yml
+  # https://github.com/Automattic/chatrix/actions/workflows/create-release.yml
   workflow_dispatch:
 
   push:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -6,10 +6,38 @@ on:
   workflow_dispatch:
 
   push:
-    tags: ['v*']
+    branches:
+      - main
+    paths:
+      - 'package.json'
 
 jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.output.outputs.changed }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - uses: salsify/action-detect-and-tag-new-version@v2
+        id: check-version
+        with:
+          version-command: jq '.version' package.json
+          create-tag: false
+
+      - name: Set output if version changed
+        if: steps.check-version.outputs.current-version != steps.check-version.outputs.previous-version
+        id: output
+        run: |
+          echo "Detected version change from ${{steps.check-version.outputs.previous-version}} to ${{steps.check-version.outputs.current-version}}"
+          echo ::set-output name=changed::true
+
   create-release:
+    needs: check-version
+    if: needs.check-version.outputs.changed == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,8 +35,5 @@ jobs:
       - name: Run eslint
         run: yarn lint
 
-      - name: Build block
-        run: yarn build:block
-
-      - name: Build popup
-        run: yarn build:popup
+      - name: Build
+        run: yarn build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,9 +33,6 @@ Run `phpcs`:
 ./vendor/bin/phpcs
 ```
 
-## Upgrading frontend
-If you wish to upgrade the version of [chatrix-frontend](https://github.com/Automattic/chatrix-frontend) used by this plugin, you can do so by editing `$VERSION` in [`bin/fetch-frontend.sh`](bin/fetch-frontend.sh). This will result in that version being used in the next release of this plugin.
-
 ## Releasing
 Chatrix releases are automatically created through a GitHub Action, which is executed whenever a tag of the form `vX.Y.Z` is pushed. You can create and push a tag with:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,12 +34,25 @@ Run `phpcs`:
 ```
 
 ## Releasing
-Chatrix releases are automatically created through a GitHub Action, which is executed whenever a tag of the form `vX.Y.Z` is pushed. You can create and push a tag with:
+Issuing a new release is a semi-automated process which consists of the following steps:
+
+1. In your local machine, run the `bin/prepare-release.sh` script, which creates a Pull Request where a release can be prepared.
+2. Once the above PR is merged, a GitHub Action will be triggered which will create a release on GitHub.
+3. Once a release is created on GitHub, a GitHub Action will be triggered which will publish the release to the WordPress Plugin Directory.
+
+### Preparing a release
+
+> You'll need [`jq`](https://stedolan.github.io/jq), which on macOS can be installed with `brew install jq`.
+
+> You'll need the [GitHub CLI](https://cli.github.com), which on macOS can be installed with `brew install gh`.
+
+You can prepare a release with the following command (using `v1.2.3` as example):
+
+> Make sure to consider [Semantic Versioning](https://semver.org) to decide which version you're issuing.
+
 
 ```shell
-# Make sure you consider https://semver.org to decide which version you're issuing.
-# Note the version must not be prefixed with a "v", e.g. it should be 1.2.3, not v1.2.3.  
 bin/prepare-release.sh 1.2.3
 ```
 
-Running the above script will trigger the [GitHub Action](https://github.com/Automattic/chatrix/actions), which when completed will have created a **draft release** for the tag that was pushed. You should then edit that release to provide a meaningful title and description (ideally including a [changelog](https://keepachangelog.com/en/1.0.0/)), then publish the release through the GitHub UI.
+Running the above script will create the Pull Request where a release can be prepared. Once the PR is merged, a GitHub Action will be triggered which will create the release.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - Tested up to: 6.1
 - Requires PHP: 7.4
 - License: [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html)
-- Stable tag: 0.2.1
+- Stable tag: 0.2.2
 - GitHub Plugin URI: https://github.com/Automattic/chatrix
 
 Matrix client for WordPress.

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -21,7 +21,7 @@ fi
 
 # Make sure we're up-to-date with origin.
 git fetch
-git pull --no-rebase origin main
+git pull --ff-only origin main
 
 # Checkout or create branch for release.
 if [[ $(git branch --list "$RELEASE_BRANCH") ]]

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -45,5 +45,4 @@ rm -f chatrix.php-e README.md-e
 git add chatrix.php README.md
 
 git commit -m "Release v$VERSION"
-git tag "v$VERSION"
-git push --tags origin "$RELEASE_BRANCH"
+git push origin "$RELEASE_BRANCH"

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -44,5 +44,15 @@ sed -i"" -e "s/\(- Stable tag: \)\(.*\)/\1$VERSION/g" README.md
 rm -f chatrix.php-e README.md-e
 git add chatrix.php README.md
 
+git --no-pager diff --cached
+
+printf "\n\n"
+read -p "Would you like to commit and push the above diff to the $RELEASE_BRANCH branch? [y|n] " yn
+case $yn in
+	yes|y ) ;;
+	* )
+	  error "Exiting without committing."
+esac
+
 git commit -m "Release v$VERSION"
 git push origin "$RELEASE_BRANCH"

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -31,21 +31,21 @@ else
   git checkout -b "$RELEASE_BRANCH"
 fi
 
+# Substitute version in all relevant files.
 for file in package.json composer.json block/block.json
 do
   jq ".version = \"$VERSION\"" $file > $file.tmp
   mv $file.tmp $file
   git add $file
 done
-
 sed -i"" -e "s/\(Version: \)\(.*\)/\1$VERSION/g" chatrix.php
 sed -i"" -e "s/\(\$version = '\)\(.*\)/\1$VERSION';/g" chatrix.php
 sed -i"" -e "s/\(- Stable tag: \)\(.*\)/\1$VERSION/g" README.md
 rm -f chatrix.php-e README.md-e
 git add chatrix.php README.md
 
+# Show diff and ask for confirmation.
 git --no-pager diff --cached
-
 printf "\n\n"
 read -p "Would you like to commit, push and open a PR for the above diff? [y|n] " yn
 case $yn in
@@ -55,6 +55,7 @@ case $yn in
 	  error "Exiting without committing."
 esac
 
+# Commit, push and open PR.
 git commit -m "Release v$VERSION"
 git push -u origin "$RELEASE_BRANCH"
 gh pr create --base main --fill --title "Release v$VERSION" --assignee @me --reviewer akirk,ashfame,psrpinto

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -47,12 +47,17 @@ git add chatrix.php README.md
 git --no-pager diff --cached
 
 printf "\n\n"
-read -p "Would you like to commit and push the above diff to the $RELEASE_BRANCH branch? [y|n] " yn
+read -p "Would you like to commit, push and open a PR for the above diff? [y|n] " yn
 case $yn in
-	yes|y ) ;;
+	yes|y )
+	  echo "Ok, continuing";;
 	* )
 	  error "Exiting without committing."
 esac
 
 git commit -m "Release v$VERSION"
-git push origin "$RELEASE_BRANCH"
+git push -u origin "$RELEASE_BRANCH"
+gh pr create --base main --fill --title "Release v$VERSION" --assignee @me --reviewer akirk,ashfame,psrpinto
+
+echo "A Pull Request has been created for Release v$VERSION (see URL above)."
+echo "The release will automatically be created once the Pull Request is merged."

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -12,6 +12,11 @@ if [ -z "$1" ]; then
 fi
 
 VERSION=$1
+if [[ $VERSION == v* ]]; then
+  # Strip leading v.
+  VERSION="${VERSION:1}"
+fi
+
 RELEASE_BRANCH="release-$VERSION"
 
 CURRENT_BRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -63,7 +63,7 @@ esac
 # Commit, push and open PR.
 git commit -m "Release v$VERSION"
 git push -u origin "$RELEASE_BRANCH"
-gh pr create --base main --fill --title "Release v$VERSION" --assignee @me --reviewer akirk,ashfame,psrpinto
+gh pr create --base main --label "Prepare Release" --fill --title "Release v$VERSION" --assignee @me --reviewer akirk,ashfame,psrpinto
 
 echo "A Pull Request has been created for Release v$VERSION (see URL above)."
 echo "The release will automatically be created once the Pull Request is merged."

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -15,7 +15,7 @@ VERSION=$1
 RELEASE_BRANCH="release-$VERSION"
 
 CURRENT_BRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
-if [ "$CURRENT_BRANCH" != "main" ]; then
+if [[ "$CURRENT_BRANCH" != "main" ]] && [[ "$CURRENT_BRANCH" != "$RELEASE_BRANCH" ]]; then
   error "You must be on branch main"
 fi
 

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -12,15 +12,24 @@ if [ -z "$1" ]; then
 fi
 
 VERSION=$1
+RELEASE_BRANCH="release-$VERSION"
 
 CURRENT_BRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
 if [ "$CURRENT_BRANCH" != "main" ]; then
   error "You must be on branch main"
 fi
 
-git checkout main
+# Make sure we're up-to-date with origin.
 git fetch
 git pull --no-rebase origin main
+
+# Checkout or create branch for release.
+if [[ $(git branch --list "$RELEASE_BRANCH") ]]
+then
+  git checkout "$RELEASE_BRANCH"
+else
+  git checkout -b "$RELEASE_BRANCH"
+fi
 
 for file in package.json composer.json block/block.json
 do
@@ -37,4 +46,4 @@ git add chatrix.php README.md
 
 git commit -m "Release v$VERSION"
 git tag "v$VERSION"
-git push --tags origin main
+git push --tags origin "$RELEASE_BRANCH"

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -1,11 +1,22 @@
 set -e
 
+function error {
+  RED='\033[0;31m'
+  NONE='\033[0m'
+  printf "$RED$1$NONE\n"
+  exit 1
+}
+
 if [ -z "$1" ]; then
-    echo "Provide a new version, current version is $(jq '.version' package.json)"
-    exit 1
+    error "Provide a new version, current version is $(jq '.version' package.json)"
 fi
 
 VERSION=$1
+
+CURRENT_BRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
+if [ "$CURRENT_BRANCH" != "main" ]; then
+  error "You must be on branch main"
+fi
 
 git checkout main
 git fetch

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -20,7 +20,7 @@ fi
 
 git checkout main
 git fetch
-git pull origin main
+git pull --no-rebase origin main
 
 for file in package.json composer.json block/block.json
 do

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -33,7 +33,7 @@ sed -i"" -e "s/\(Version: \)\(.*\)/\1$VERSION/g" chatrix.php
 sed -i"" -e "s/\(\$version = '\)\(.*\)/\1$VERSION';/g" chatrix.php
 sed -i"" -e "s/\(- Stable tag: \)\(.*\)/\1$VERSION/g" README.md
 rm -f chatrix.php-e README.md-e
-git add chatrix.php
+git add chatrix.php README.md
 
 git commit -m "Release v$VERSION"
 git tag "v$VERSION"

--- a/block/block.json
+++ b/block/block.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "apiVersion": 2,
   "name": "automattic/chatrix",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "title": "Chatrix",
   "category": "embed",
   "icon": "format-chat",

--- a/chatrix.php
+++ b/chatrix.php
@@ -5,7 +5,7 @@
  * Author: Automattic
  * Author URI: https://automattic.com/
  * Plugin URI: https://github.com/Automattic/chatrix
- * Version: 0.2.1
+ * Version: 0.2.2
  */
 
 use function Automattic\Chatrix\Admin\main as adminMain;
@@ -22,7 +22,7 @@ function automattic_chatrix_version(): string {
 	}
 
 	// Do not edit this line, it's automatically set by bin/prepare-release.sh.
-	$version = '0.2.1';
+	$version = '0.2.2';
 
 	return $version;
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/chatrix",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "WordPress plugin to embed a Matrix client into WordPress pages.",
   "type": "wordpress-plugin",
   "license": "GPL",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatrix",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Embedded Matrix client for WordPress",
   "repository": "git@github.com:Automattic/chatrix.git",
   "author": "Automattic",


### PR DESCRIPTION
- Output errors in red
- Don't rebase when pulling
- Must also commit README.md
- Prepare release on a dedicated branch, instead of main
- Don't create a tag when preparing release
- Ask user if they want to push the release commit
- Use to level build script
- Allow using a pre-existing branch
- Create PR
- Remove no longer needed section
- Use --ff-only instead of --no-rebase
- Add comments
- Strip leading v
- Document how to issue a release
- Rename action
- Create release if version in package.json changed
- Label PR with Release
- Release v0.2.2
