### PR TITLE
Release v0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - Tested up to: 6.1
 - Requires PHP: 7.4
 - License: [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html)
-- Stable tag: 0.3.0
+- Stable tag: 0.3.1
 - GitHub Plugin URI: https://github.com/Automattic/chatrix
 
 Matrix client for WordPress.

--- a/block/block.json
+++ b/block/block.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "apiVersion": 2,
   "name": "automattic/chatrix",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "title": "Chatrix",
   "category": "embed",
   "icon": "format-chat",

--- a/chatrix.php
+++ b/chatrix.php
@@ -5,7 +5,7 @@
  * Author: Automattic
  * Author URI: https://automattic.com/
  * Plugin URI: https://github.com/Automattic/chatrix
- * Version: 0.3.0
+ * Version: 0.3.1
  */
 
 use function Automattic\Chatrix\Admin\main as adminMain;
@@ -22,7 +22,7 @@ function automattic_chatrix_version(): string {
 	}
 
 	// Do not edit this line, it's automatically set by bin/prepare-release.sh.
-	$version = '0.3.0';
+	$version = '0.3.1';
 
 	return $version;
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/chatrix",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "WordPress plugin to embed a Matrix client into WordPress pages.",
   "type": "wordpress-plugin",
   "license": "GPL",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatrix",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Embedded Matrix client for WordPress",
   "repository": "git@github.com:Automattic/chatrix.git",
   "author": "Automattic",


### PR DESCRIPTION
Forcing a new release since release process [was broken](https://github.com/Automattic/chatrix/pull/109).