### PR TITLE
Remove yarn.lock and package.json from release artifacts

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -87,6 +87,8 @@ jobs:
           rm -rf /tmp/release/node_modules
           rm -rf /tmp/release/frontend
           rm -rf /tmp/release/block
+          rm -rf /tmp/release/yarn.lock
+          rm -rf /tmp/release/package.json
 
       - name: Move and rename release directory
         run: mv /tmp/release chatrix

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "02f21b5725a632417ac6bc4dc314832c",
+    "content-hash": "a847011228aaa8082276727e0de98f6e",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
They're not needed in the built artifacts, and reduces file size.

Also took the opportunity to update the hash in `composer.lock`, otherwise there's a warning when building due to `composer.lock` not being up-to-date compared to `composer.json`.