### PR TITLE
Script for creating release artifacts

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -55,51 +55,9 @@ jobs:
           node-version: '16'
           cache: 'yarn'
 
-      - name: Install composer dependencies
-        run: composer install --no-ansi --no-dev --no-interaction --no-plugins --no-scripts --optimize-autoloader
-
-      - name: Install npm dependencies
-        run: yarn install
-
-      - name: Build frontend
-        run: yarn build
-
-      - name: Create directory for release
-        run: mkdir /tmp/release
-
-      - name: Copy all files to release directory
-        run: cp -r ./* /tmp/release/
-
-      - name: Remove unnecessary files and directories
-        run: |
-          rm -rf /tmp/release/.github
-          rm -rf /tmp/release/.git
-          rm -rf /tmp/release/.gitignore
-          rm -rf /tmp/release/.editorconfig
-          rm -rf /tmp/release/.eslintrc.js
-          rm -rf /tmp/release/.wp-env.json
-          rm -rf /tmp/release/bin
-          rm -rf /tmp/release/CONTRIBUTING.md
-          rm -rf /tmp/release/Makefile
-          rm -rf /tmp/release/phpcs.xml
-          rm -rf /tmp/release/tsconfig.json
-          rm -rf /tmp/release/build/.tmp
-          rm -rf /tmp/release/node_modules
-          rm -rf /tmp/release/frontend
-          rm -rf /tmp/release/block
-          rm -rf /tmp/release/yarn.lock
-          rm -rf /tmp/release/package.json
-
-      - name: Move and rename release directory
-        run: mv /tmp/release chatrix
-
-      - name: Create zip archive for release
-        uses: montudor/action-zip@v1
-        with:
-          args: zip -qq -r chatrix-${{ env.version }}.zip chatrix
-
-      - name: Create tar archive for release
-        run: tar -cvzf chatrix-${{ env.version }}.tar.gz chatrix
+      - name: Create artifacts
+        run:
+          shell: bin/create-release-artifacts.sh ${{ env.version }}
 
       - name: Create release
         uses: ncipollo/release-action@v1
@@ -107,6 +65,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.version }}
           commit: ${{ github.sha }}
-          artifacts: "chatrix-${{ env.version }}.tar.gz,chatrix-${{ env.version }}.zip"
+          artifacts: "release/chatrix-${{ env.version }}.tar.gz,release/chatrix-${{ env.version }}.zip"
           artifactErrorsFailBuild: true
           draft: true

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /vendor/
 /node_modules/
 /build/
+/release/
 .env.*.local

--- a/bin/create-release-artifacts.sh
+++ b/bin/create-release-artifacts.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+function error {
+  RED='\033[0;31m'
+  NONE='\033[0m'
+  printf "$RED$1$NONE\n"
+  exit 1
+}
+
+if [ -z "$1" ]; then
+    error "Provide a version, current version is $(jq '.version' package.json)"
+fi
+
+VERSION=$1
+if [[ $VERSION == v* ]]; then
+  # Strip leading v.
+  VERSION="${VERSION:1}"
+fi
+
+RELEASE_DIR="$(pwd)/release/$VERSION"
+
+rm -rf "$RELEASE_DIR" && mkdir -p "$RELEASE_DIR"

--- a/bin/create-release-artifacts.sh
+++ b/bin/create-release-artifacts.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+shopt -s extglob
 
 function error {
   RED='\033[0;31m'
@@ -20,5 +21,22 @@ if [[ $VERSION == v* ]]; then
 fi
 
 RELEASE_DIR="$(pwd)/release/$VERSION"
-
 rm -rf "$RELEASE_DIR" && mkdir -p "$RELEASE_DIR"
+
+yarn install
+yarn build
+
+PATHS_TO_INCLUDE=(
+"build"
+"src"
+"chatrix.php"
+"LICENSE"
+"README.md"
+)
+for path in "${PATHS_TO_INCLUDE[@]}";do
+    cp -r "$path" "$RELEASE_DIR/$path"
+done
+
+rm -rf "$RELEASE_DIR/build/.tmp"
+
+COMPOSER_VENDOR_DIR="$RELEASE_DIR/vendor" composer install --no-ansi --no-dev --no-interaction --no-plugins --no-scripts --optimize-autoloader

--- a/bin/create-release-artifacts.sh
+++ b/bin/create-release-artifacts.sh
@@ -20,7 +20,8 @@ if [[ $VERSION == v* ]]; then
   VERSION="${VERSION:1}"
 fi
 
-RELEASE_DIR="$(pwd)/release/$VERSION"
+RELEASE_ROOT_DIR="$(pwd)/release"
+RELEASE_DIR="$RELEASE_ROOT_DIR/$VERSION"
 rm -rf "$RELEASE_DIR" && mkdir -p "$RELEASE_DIR"
 
 yarn install
@@ -34,9 +35,18 @@ PATHS_TO_INCLUDE=(
 "README.md"
 )
 for path in "${PATHS_TO_INCLUDE[@]}";do
-    cp -r "$path" "$RELEASE_DIR/$path"
+  cp -r "$path" "$RELEASE_DIR/$path"
 done
 
 rm -rf "$RELEASE_DIR/build/.tmp"
 
 COMPOSER_VENDOR_DIR="$RELEASE_DIR/vendor" composer install --no-ansi --no-dev --no-interaction --no-plugins --no-scripts --optimize-autoloader
+
+# Rename release directory from version name (e.g. 1.2.3) to `chatrix` so that root directory in the artifacts is named `chatrix`.
+# Then create the archives, and rename back to the versioned name (e.g. 1.2.3).
+rm -rf "$RELEASE_ROOT_DIR/chatrix"
+mv "$RELEASE_DIR" "$RELEASE_ROOT_DIR/chatrix"
+cd "$RELEASE_ROOT_DIR"
+zip -r "chatrix-$VERSION.zip" chatrix
+tar -cvzf "chatrix-$VERSION.tar.gz" chatrix
+mv "$RELEASE_ROOT_DIR/chatrix" "$RELEASE_DIR"

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -e
 
 function error {


### PR DESCRIPTION
I need to be able to generate the artifacts locally (not the zip/tar files themselves, but their contents) to upload to the plugin directory. We'll also need this logic in the upcoming Action that will submit a new release to the plugin directory.

So this PR extracts the logic for creating the release artifacts out of the Action, and into a script that can be ran anywhere, including local environments.