### PR TITLE
README fixes for plugin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /build/
 /release/
 .env.*.local
+/svn/

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This plugin can be used in two distinct ways:
 ### Is there a more flexible way to configure the popup?
 Yes. Instead of configuring the _popup_ through `Settings -> Chatrix`, you can configure it through code, by using the `chatrix_instances` filter:
 
-```
+`
 // functions.php
 
 add_filter( 'chatrix_instances', function ( array $default_instances ) {
@@ -49,7 +49,7 @@ add_filter( 'chatrix_instances', function ( array $default_instances ) {
 		),
 	);
 } );
-```
+`
 
 ### How can I add a border around the block?
 To add a border around the Chatrix block, you can place it inside a Group block. The Group block allows you to set a border, rounded corners, and other styling properties.

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Easily add a [Matrix](https://matrix.org) client to WordPress pages, either thro
 ![Popup](assets/screenshot-2.png)
 
 ## Frequently Asked Questions
-## How can I install this plugin on my site?
+### How can I install this plugin on my site?
 This plugin can be used in two distinct ways:
 
 1. By adding a block to a page through the block editor
 2. By selecting pages in which a _popup_ will be displayed. You configure this through `Settings -> Chatrix`.
 
-## Is there a more flexible way to configure the _popup_?
+### Is there a more flexible way to configure the popup?
 Yes. Instead of configuring the _popup_ through `Settings -> Chatrix`, you can configure it through code, by using the `chatrix_instances` filter:
 
 ```

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Easily add a [Matrix](https://matrix.org) client to WordPress pages, either thro
 ![Block](assets/screenshot-1.png)
 ![Popup](assets/screenshot-2.png)
 
-## Usage
+## Frequently Asked Questions
+## How can I install this plugin on my site?
 This plugin can be used in two distinct ways:
 
 1. By adding a block to a page through the block editor
 2. By selecting pages in which a _popup_ will be displayed. You configure this through `Settings -> Chatrix`.
 
-## Frequently Asked Questions
 ### How can I add a border around the block?
 To add a border around the Chatrix block, you can place it inside a Group block. The Group block allows you to set a border, rounded corners, and other styling properties.
 

--- a/README.md
+++ b/README.md
@@ -25,16 +25,10 @@ This plugin can be used in two distinct ways:
 1. By adding a block to a page through the block editor
 2. By selecting pages in which a _popup_ will be displayed. You configure this through `Settings -> Chatrix`.
 
-### How can I add a border around the block?
-To add a border around the Chatrix block, you can place it inside a Group block. The Group block allows you to set a border, rounded corners, and other styling properties.
+## Is there a more flexible way to configure the _popup_?
+Yes. Instead of configuring the _popup_ through `Settings -> Chatrix`, you can configure it through code, by using the `chatrix_instances` filter:
 
-## Advanced usage
-> This only applies to the _popup_, not to the block.
-
-If you need more flexibility than what the plugin's settings provides, you can configure chatrix though
-the `chatrix_instances` filter:
-
-```php
+```
 // functions.php
 
 add_filter( 'chatrix_instances', function ( array $default_instances ) {
@@ -56,3 +50,6 @@ add_filter( 'chatrix_instances', function ( array $default_instances ) {
 	);
 } );
 ```
+
+### How can I add a border around the block?
+To add a border around the Chatrix block, you can place it inside a Group block. The Group block allows you to set a border, rounded corners, and other styling properties.


### PR DESCRIPTION
Non-standard sections are discouraged so we move stuff to FAQs instead.

These fixes have already been applied, see the result at https://wordpress.org/plugins/chatrix/