### PR TITLE
Layout improvements

### DIFF
--- a/frontend/styles/theme/theme.css
+++ b/frontend/styles/theme/theme.css
@@ -30,3 +30,8 @@ body {
     box-shadow: none;
     border-radius: 0;
 }
+
+/* Remove link to hydrogen on GitHub. */
+.PreSessionScreen a[href*="https://github.com/vector-im/hydrogen-web"] {
+    display: none;
+}

--- a/frontend/styles/theme/theme.css
+++ b/frontend/styles/theme/theme.css
@@ -24,3 +24,9 @@ body {
         width: 590px;
     }
 }
+
+/* Remove drop-shadow around pre-sessions screen. */
+.PreSessionScreen {
+    box-shadow: none;
+    border-radius: 0;
+}

--- a/frontend/styles/theme/theme.css
+++ b/frontend/styles/theme/theme.css
@@ -25,16 +25,19 @@ body {
     }
 }
 
+/* Remove drop-shadow around pre-session screen. */
 .PreSessionScreen {
-    /* Remove drop-shadow around pre-session screen. */
     box-shadow: none;
     border-radius: 0;
+}
 
-    /* Remove whitespace on top of pre-session screen. */
+/* Reduce whitespace to remove vertical scrollbars in login screen. */
+.PreSessionScreen {
     margin-top: 0;
-
-    /* Reduce padding to remove vertical scrollbars in login screen. */
     padding: 24px;
+}
+.PreSessionScreen .LoginView_separator {
+    margin: -2px;
 }
 
 /* Remove link to hydrogen on GitHub. */

--- a/frontend/styles/theme/theme.css
+++ b/frontend/styles/theme/theme.css
@@ -25,10 +25,13 @@ body {
     }
 }
 
-/* Remove drop-shadow around pre-sessions screen. */
 .PreSessionScreen {
+    /* Remove drop-shadow around pre-session screen. */
     box-shadow: none;
     border-radius: 0;
+
+    /* Remove whitespace on top of pre-session screen. */
+    margin-top: 0;
 }
 
 /* Remove link to hydrogen on GitHub. */

--- a/frontend/styles/theme/theme.css
+++ b/frontend/styles/theme/theme.css
@@ -21,7 +21,7 @@ body {
 /* Remove horizontal scrollbars in pre-session screen. */
 @media screen and (min-width: 600px) {
     .PreSessionScreen {
-        width: 590px;
+        width: 570px;
     }
 }
 

--- a/frontend/styles/theme/theme.css
+++ b/frontend/styles/theme/theme.css
@@ -41,3 +41,8 @@ body {
 .PreSessionScreen a[href*="https://github.com/vector-im/hydrogen-web"] {
     display: none;
 }
+
+/* Remove vertical scrollbars in logout screen. */
+.LogoutScreen {
+    height: 90vh;
+}

--- a/frontend/styles/theme/theme.css
+++ b/frontend/styles/theme/theme.css
@@ -17,3 +17,10 @@ body {
 .RootView.single-room-mode .RoomHeader .close-middle {
     display: none !important;
 }
+
+/* Remove horizontal scrollbars in pre-session screen. */
+@media screen and (min-width: 600px) {
+    .PreSessionScreen {
+        width: 590px;
+    }
+}

--- a/frontend/styles/theme/theme.css
+++ b/frontend/styles/theme/theme.css
@@ -32,6 +32,9 @@ body {
 
     /* Remove whitespace on top of pre-session screen. */
     margin-top: 0;
+
+    /* Reduce padding to remove vertical scrollbars in login screen. */
+    padding: 24px;
 }
 
 /* Remove link to hydrogen on GitHub. */

--- a/frontend/targets/block/parent.css
+++ b/frontend/targets/block/parent.css
@@ -17,10 +17,14 @@ body {
 .automattic-chatrix-container {
     width: 600px;
     height: 600px;
+    border-radius: 12px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1), 0 14px 64px -10px rgba(0, 0, 0, 0.2);
 }
 
 .automattic-chatrix-iframe {
     width: 100%;
     height: 100%;
     border: 0;
+    border-radius: inherit;
+    overflow: hidden;
 }

--- a/frontend/targets/block/parent.css
+++ b/frontend/targets/block/parent.css
@@ -5,21 +5,18 @@
 html, body {
     margin: 0;
     padding: 0;
-    width: 100%;
     height: 100%;
 }
 
 body {
-    width: 100%;
-    height: 100%;
     display: flex;
     justify-content: center;
     align-items: center;
 }
 
 .automattic-chatrix-container {
-    width: 550px;
-    height: 650px;
+    width: 600px;
+    height: 600px;
 }
 
 .automattic-chatrix-iframe {


### PR DESCRIPTION
Fixes #122

## Summary of changes
- Remove scrollbars in pre-session screens (session selection, login, logout)
- Remove drop shadow around pre-session screens

## Screenshots

| Before | After |
|-----|-----|
| <img width="746" alt="Screenshot 2022-11-21 at 15 28 51" src="https://user-images.githubusercontent.com/550401/203097390-d9eb6549-eacf-4828-8b8d-69a58bdc5115.png"> | <img width="732" alt="Screenshot 2022-11-21 at 15 35 15" src="https://user-images.githubusercontent.com/550401/203097637-58c32e78-d360-48b8-a13e-79e6adafe1ab.png"> |
| <img width="453" alt="Screenshot 2022-11-21 at 15 30 14" src="https://user-images.githubusercontent.com/550401/203097765-178b7a2b-d06c-44c8-b9e6-2909b7ca6368.png"> | <img width="427" alt="Screenshot 2022-11-21 at 15 34 51" src="https://user-images.githubusercontent.com/550401/203097790-3f6d7881-d508-4763-a54b-e0e021e643f8.png"> |
| <img width="721" alt="Screenshot 2022-11-21 at 15 28 36" src="https://user-images.githubusercontent.com/550401/203097938-8d8fa2f3-fb1d-4b71-8076-438b7847db9c.png"> | <img width="771" alt="Screenshot 2022-11-21 at 15 35 41" src="https://user-images.githubusercontent.com/550401/203097948-8e917536-400e-4b67-94da-c12b3767073b.png"> |
| <img width="820" alt="Screenshot 2022-11-21 at 15 49 10" src="https://user-images.githubusercontent.com/550401/203098539-02b03884-66eb-4539-8eb3-e98d3c4f601a.png"> | <img width="749" alt="Screenshot 2022-11-21 at 15 49 02" src="https://user-images.githubusercontent.com/550401/203098546-0c09bf6b-d549-4a18-943c-89a818cbed16.png"> |
