### PR TITLE
Improve single room mode

### DIFF
--- a/frontend/iframe/styles/theme/theme.css
+++ b/frontend/iframe/styles/theme/theme.css
@@ -17,6 +17,14 @@ body {
 .RootView.single-room-mode .SessionView .LeftPanel  {
     display: none;
 }
+.RootView.single-room-mode .RightPanelView {
+    grid-area: middle / right;
+}
+@media screen and (max-width: 800px) {
+    .RootView.single-room-mode .RightPanelView {
+        grid-area: middle;
+    }
+}
 
 /* Make the middle take all the grid when in single-room mode. */
 .RootView.single-room-mode .SessionView {

--- a/frontend/iframe/styles/theme/theme.css
+++ b/frontend/iframe/styles/theme/theme.css
@@ -26,9 +26,9 @@ body {
         320px   1fr;
 }
 
-/* Hide back button when in single-room mode. */
-.RootView.single-room-mode .RoomHeader .close-middle {
-    display: none !important;
+/* Always show the back button in single-room mode. */
+.RootView.single-room-mode .close-middle {
+    display: block;
 }
 
 /* Remove horizontal scrollbars in pre-session screen. */

--- a/frontend/iframe/styles/theme/theme.css
+++ b/frontend/iframe/styles/theme/theme.css
@@ -13,6 +13,19 @@ body {
     left: 0;
 }
 
+/* Hide the left panel when in single-room mode. */
+.RootView.single-room-mode .SessionView .LeftPanel  {
+    display: none;
+}
+
+/* Make the middle take all the grid when in single-room mode. */
+.RootView.single-room-mode .SessionView {
+    grid-template:
+        "status status" auto
+        "middle middle" 1fr /
+        320px   1fr;
+}
+
 /* Hide back button when in single-room mode. */
 .RootView.single-room-mode .RoomHeader .close-middle {
     display: none !important;

--- a/frontend/iframe/viewmodels/RoomViewModel.ts
+++ b/frontend/iframe/viewmodels/RoomViewModel.ts
@@ -9,6 +9,10 @@ export class RoomViewModel extends BaseRoomViewModel {
         super.load();
     }
 
+    get singleRoomMode(): boolean {
+        return !!super.platform.config.roomId;
+    }
+
     get navigation() {
         return super.navigation;
     }

--- a/frontend/iframe/viewmodels/RoomViewModel.ts
+++ b/frontend/iframe/viewmodels/RoomViewModel.ts
@@ -1,4 +1,7 @@
+import { SegmentType } from "hydrogen-web/src/domain/navigation";
+import { Segment } from "hydrogen-web/src/domain/navigation/Navigation";
 import { RoomViewModel as BaseRoomViewModel } from "hydrogen-web/src/domain/session/room/RoomViewModel";
+import { URLRouter } from "../platform/URLRouter";
 
 export class RoomViewModel extends BaseRoomViewModel {
     constructor(options) {
@@ -7,6 +10,20 @@ export class RoomViewModel extends BaseRoomViewModel {
 
     async load() {
         super.load();
+    }
+
+    get urlRouter(): URLRouter {
+        return super.urlRouter;
+    }
+
+    get closeUrl() {
+        if (this.singleRoomMode) {
+            const path = this.navigation.path.with(new Segment<SegmentType>("session"));
+
+            return this.urlRouter.urlForPath(path);
+        }
+
+        return super.closeUrl;
     }
 
     get singleRoomMode(): boolean {

--- a/frontend/iframe/viewmodels/RoomViewModel.ts
+++ b/frontend/iframe/viewmodels/RoomViewModel.ts
@@ -1,0 +1,43 @@
+import { RoomViewModel as BaseRoomViewModel } from "hydrogen-web/src/domain/session/room/RoomViewModel";
+
+export class RoomViewModel extends BaseRoomViewModel {
+    constructor(options) {
+        super(options);
+    }
+
+    async load() {
+        super.load();
+    }
+
+    get navigation() {
+        return super.navigation;
+    }
+
+    i18n(parts: TemplateStringsArray, ...expr: any[]): string {
+        return super.i18n(parts, expr);
+    }
+
+    openDetailsPanel() {
+        super.openDetailsPanel();
+    }
+
+    get canLeave() {
+        return super.canLeave;
+    }
+
+    get canForget() {
+        return super.canForget;
+    }
+
+    forgetRoom() {
+        super.forgetRoom();
+    }
+
+    get canRejoin() {
+        return super.canRejoin;
+    }
+
+    rejoinRoom() {
+        super.rejoinRoom();
+    }
+}

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -112,7 +112,7 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
                 void this._showPicker();
             }
         } else if (sessionId) {
-            if (this.platform.config.roomId) {
+            if (this.singleRoomMode) {
                 this.navigation.push("room", this.platform.config.roomId);
             }
 

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -2,12 +2,12 @@ import { ForcedLogoutViewModel } from "hydrogen-web/src/domain/ForcedLogoutViewM
 import { LoginViewModel } from "hydrogen-web/src/domain/login/LoginViewModel";
 import { LogoutViewModel } from "hydrogen-web/src/domain/LogoutViewModel";
 import { SegmentType } from "hydrogen-web/src/domain/navigation";
-import { SessionViewModel } from "hydrogen-web/src/domain/session/SessionViewModel";
 import { SessionLoadViewModel } from "hydrogen-web/src/domain/SessionLoadViewModel";
 import { SessionPickerViewModel } from "hydrogen-web/src/domain/SessionPickerViewModel";
 import { Options as BaseOptions, ViewModel } from "hydrogen-web/src/domain/ViewModel";
 import { Client } from "hydrogen-web/src/matrix/Client.js";
 import { allSections, Section } from "../platform/Navigation";
+import { SessionViewModel } from "./SessionViewModel";
 
 type Options = {} & BaseOptions;
 

--- a/frontend/iframe/viewmodels/SessionViewModel.ts
+++ b/frontend/iframe/viewmodels/SessionViewModel.ts
@@ -15,6 +15,43 @@ export class SessionViewModel extends BaseSessionViewModel {
         super.start();
     }
 
+    i18n(parts: TemplateStringsArray, ...expr: any[]): string {
+        return super.i18n(parts, expr);
+    }
+
+    get activeMiddleViewModel() {
+        return super.activeMiddleViewModel;
+    }
+
+    get roomGridViewModel() {
+        return super.roomGridViewModel;
+    }
+
+    get leftPanelViewModel() {
+        return super.leftPanelViewModel;
+    }
+
+    get sessionStatusViewModel() {
+        return super.sessionStatusViewModel;
+    }
+
+    get currentRoomViewModel() {
+        // @ts-ignore
+        return this._roomViewModelObservable?.get();
+    }
+
+    get rightPanelViewModel() {
+        return super.rightPanelViewModel;
+    }
+
+    get createRoomViewModel() {
+        return super.createRoomViewModel;
+    }
+
+    get joinRoomViewModel() {
+        return super.joinRoomViewModel;
+    }
+
     _updateSettings(settingsOpen) {
         if (this.settingsViewModel) {
             this.settingsViewModel = super.disposeTracked(super.settingsViewModel);
@@ -28,7 +65,7 @@ export class SessionViewModel extends BaseSessionViewModel {
         super.emitChange("activeMiddleViewModel");
     }
 
-    private get settingsViewModel(): SettingsViewModel {
+    get settingsViewModel(): SettingsViewModel {
         // @ts-ignore
         return this._settingsViewModel;
     }

--- a/frontend/iframe/viewmodels/SessionViewModel.ts
+++ b/frontend/iframe/viewmodels/SessionViewModel.ts
@@ -1,0 +1,19 @@
+import { SessionViewModel as BaseSessionViewModel } from "hydrogen-web/src/domain/session/SessionViewModel";
+
+export class SessionViewModel extends BaseSessionViewModel {
+    constructor(options) {
+        super(options);
+    }
+
+    get id() {
+        return super.id;
+    }
+
+    start() {
+        super.start();
+    }
+
+    dispose(): void {
+        super.dispose();
+    }
+}

--- a/frontend/iframe/viewmodels/SessionViewModel.ts
+++ b/frontend/iframe/viewmodels/SessionViewModel.ts
@@ -1,5 +1,6 @@
 import { SessionViewModel as BaseSessionViewModel } from "hydrogen-web/src/domain/session/SessionViewModel";
 import { RoomViewModel } from "./RoomViewModel";
+import { SettingsViewModel } from "./SettingsViewModel";
 
 export class SessionViewModel extends BaseSessionViewModel {
     constructor(options) {
@@ -12,6 +13,29 @@ export class SessionViewModel extends BaseSessionViewModel {
 
     start() {
         super.start();
+    }
+
+    _updateSettings(settingsOpen) {
+        if (this.settingsViewModel) {
+            this.settingsViewModel = super.disposeTracked(super.settingsViewModel);
+        }
+        if (settingsOpen) {
+            this.settingsViewModel = super.track(new SettingsViewModel(super.childOptions({
+                client: this.client,
+            })));
+            void this.settingsViewModel.load();
+        }
+        super.emitChange("activeMiddleViewModel");
+    }
+
+    private get settingsViewModel(): SettingsViewModel {
+        // @ts-ignore
+        return this._settingsViewModel;
+    }
+
+    private set settingsViewModel(vm: SettingsViewModel) {
+        // @ts-ignore
+        this._settingsViewModel = vm;
     }
 
     dispose(): void {

--- a/frontend/iframe/viewmodels/SessionViewModel.ts
+++ b/frontend/iframe/viewmodels/SessionViewModel.ts
@@ -1,4 +1,5 @@
 import { SessionViewModel as BaseSessionViewModel } from "hydrogen-web/src/domain/session/SessionViewModel";
+import { RoomViewModel } from "./RoomViewModel";
 
 export class SessionViewModel extends BaseSessionViewModel {
     constructor(options) {
@@ -15,5 +16,30 @@ export class SessionViewModel extends BaseSessionViewModel {
 
     dispose(): void {
         super.dispose();
+    }
+
+    private get client() {
+        // @ts-ignore
+        return this._client;
+    }
+
+    _createRoomViewModelInstance(roomId) {
+        const room = this.client.session.rooms.get(roomId);
+        if (room) {
+            const roomVM = new RoomViewModel(super.childOptions({room}));
+            void roomVM.load();
+            return roomVM;
+        }
+        return null;
+    }
+
+    async _createArchivedRoomViewModel(roomId) {
+        const room = await this.client.session.loadArchivedRoom(roomId);
+        if (room) {
+            const roomVM = new RoomViewModel(super.childOptions({room}));
+            void roomVM.load();
+            return roomVM;
+        }
+        return null;
     }
 }

--- a/frontend/iframe/viewmodels/SettingsViewModel.ts
+++ b/frontend/iframe/viewmodels/SettingsViewModel.ts
@@ -1,0 +1,11 @@
+import { SettingsViewModel as BaseSettingsViewModel } from "hydrogen-web/src/domain/session/settings/SettingsViewModel";
+
+export class SettingsViewModel extends BaseSettingsViewModel {
+    constructor(options) {
+        super(options);
+    }
+
+    async load() {
+        return super.load();
+    }
+}

--- a/frontend/iframe/viewmodels/SettingsViewModel.ts
+++ b/frontend/iframe/viewmodels/SettingsViewModel.ts
@@ -1,4 +1,7 @@
+import { SegmentType } from "hydrogen-web/src/domain/navigation";
+import { Segment } from "hydrogen-web/src/domain/navigation/Navigation";
 import { SettingsViewModel as BaseSettingsViewModel } from "hydrogen-web/src/domain/session/settings/SettingsViewModel";
+import { URLRouter } from "../platform/URLRouter";
 
 export class SettingsViewModel extends BaseSettingsViewModel {
     constructor(options) {
@@ -7,5 +10,28 @@ export class SettingsViewModel extends BaseSettingsViewModel {
 
     async load() {
         return super.load();
+    }
+
+    get urlRouter(): URLRouter {
+        return super.urlRouter;
+    }
+
+    get navigation() {
+        return super.navigation;
+    }
+
+    get closeUrl() {
+        if (this.singleRoomMode) {
+            const roomId = super.platform.config.roomId;
+            const path = this.navigation.path.with(new Segment<SegmentType>("room", roomId));
+
+            return this.urlRouter.urlForPath(path);
+        }
+
+        return super.closeUrl;
+    }
+
+    get singleRoomMode(): boolean {
+        return !!super.platform.config.roomId;
     }
 }

--- a/frontend/iframe/views/RoomView.ts
+++ b/frontend/iframe/views/RoomView.ts
@@ -1,5 +1,5 @@
-import { RoomViewModel } from "hydrogen-web/src/domain/session/room/RoomViewModel.js";
 import { RoomView as BaseRoomView } from "hydrogen-web/src/platform/web/ui/session/room/RoomView";
+import { RoomViewModel } from "../viewmodels/RoomViewModel";
 
 export class RoomView extends BaseRoomView {
     constructor(value: RoomViewModel, viewClassForTile) {

--- a/frontend/iframe/views/RoomView.ts
+++ b/frontend/iframe/views/RoomView.ts
@@ -1,8 +1,37 @@
+import { Menu, MenuOption } from "hydrogen-web/src/platform/web/ui/general/Menu";
+import { Popup } from "hydrogen-web/src/platform/web/ui/general/Popup";
 import { RoomView as BaseRoomView } from "hydrogen-web/src/platform/web/ui/session/room/RoomView";
 import { RoomViewModel } from "../viewmodels/RoomViewModel";
 
 export class RoomView extends BaseRoomView {
     constructor(value: RoomViewModel, viewClassForTile) {
         super(value, viewClassForTile);
+    }
+
+    _toggleOptionsMenu(evt) {
+        if (super._optionsPopup && super._optionsPopup.isOpen) {
+            super._optionsPopup.close();
+        } else {
+            const vm = super.value;
+            const options: MenuOption[] = [];
+            options.push(Menu.option(vm.i18n`Room details`, () => vm.openDetailsPanel()));
+            if (vm.canLeave) {
+                options.push(Menu.option(vm.i18n`Leave room`, () => super._confirmToLeaveRoom()).setDestructive());
+            }
+            if (vm.canForget) {
+                options.push(Menu.option(vm.i18n`Forget room`, () => vm.forgetRoom()).setDestructive());
+            }
+            if (vm.canRejoin) {
+                options.push(Menu.option(vm.i18n`Rejoin room`, () => vm.rejoinRoom()));
+            }
+            if (!options.length) {
+                return;
+            }
+            const optionsPopup = new Popup(new Menu(options));
+            optionsPopup.trackInTemplateView(this);
+            optionsPopup.showRelativeTo(evt.target, 10);
+
+            super._optionsPopup = optionsPopup;
+        }
     }
 }

--- a/frontend/iframe/views/RoomView.ts
+++ b/frontend/iframe/views/RoomView.ts
@@ -1,0 +1,8 @@
+import { RoomViewModel } from "hydrogen-web/src/domain/session/room/RoomViewModel.js";
+import { RoomView as BaseRoomView } from "hydrogen-web/src/platform/web/ui/session/room/RoomView";
+
+export class RoomView extends BaseRoomView {
+    constructor(value: RoomViewModel, viewClassForTile) {
+        super(value, viewClassForTile);
+    }
+}

--- a/frontend/iframe/views/RoomView.ts
+++ b/frontend/iframe/views/RoomView.ts
@@ -12,7 +12,7 @@ export class RoomView extends BaseRoomView {
         if (super._optionsPopup && super._optionsPopup.isOpen) {
             super._optionsPopup.close();
         } else {
-            const vm = super.value;
+            const vm: RoomViewModel = super.value;
             const options: MenuOption[] = [];
             options.push(Menu.option(vm.i18n`Room details`, () => vm.openDetailsPanel()));
             if (vm.canLeave) {
@@ -23,6 +23,9 @@ export class RoomView extends BaseRoomView {
             }
             if (vm.canRejoin) {
                 options.push(Menu.option(vm.i18n`Rejoin room`, () => vm.rejoinRoom()));
+            }
+            if (vm.singleRoomMode) {
+                options.push(Menu.option(vm.i18n`Settings`, () => vm.navigation.push("settings")));
             }
             if (!options.length) {
                 return;

--- a/frontend/iframe/views/RootView.ts
+++ b/frontend/iframe/views/RootView.ts
@@ -5,9 +5,9 @@ import { LoginView } from "hydrogen-web/src/platform/web/ui/login/LoginView";
 import { SessionLoadView } from "hydrogen-web/src/platform/web/ui/login/SessionLoadView";
 import { SessionPickerView } from "hydrogen-web/src/platform/web/ui/login/SessionPickerView";
 import { LogoutView } from "hydrogen-web/src/platform/web/ui/LogoutView";
-import { SessionView } from "hydrogen-web/src/platform/web/ui/session/SessionView";
 import { Section } from "../platform/Navigation";
 import { RootViewModel } from "../viewmodels/RootViewModel";
+import { SessionView } from "./SessionView";
 
 export class RootView extends TemplateView<RootViewModel> {
     constructor(value: RootViewModel) {

--- a/frontend/iframe/views/SessionView.ts
+++ b/frontend/iframe/views/SessionView.ts
@@ -1,8 +1,60 @@
 import { SessionViewModel } from "hydrogen-web/src/domain/session/SessionViewModel";
+import { StaticView } from "hydrogen-web/src/platform/web/ui/general/StaticView";
+import { CreateRoomView } from "hydrogen-web/src/platform/web/ui/session/CreateRoomView";
+import { JoinRoomView } from "hydrogen-web/src/platform/web/ui/session/JoinRoomView";
+import { LeftPanelView } from "hydrogen-web/src/platform/web/ui/session/leftpanel/LeftPanelView";
+import { RightPanelView } from "hydrogen-web/src/platform/web/ui/session/rightpanel/RightPanelView";
+import { viewClassForTile } from "hydrogen-web/src/platform/web/ui/session/room/common";
+import { InviteView } from "hydrogen-web/src/platform/web/ui/session/room/InviteView";
+import { LightboxView } from "hydrogen-web/src/platform/web/ui/session/room/LightboxView";
+import { RoomBeingCreatedView } from "hydrogen-web/src/platform/web/ui/session/room/RoomBeingCreatedView";
+import { RoomView } from "hydrogen-web/src/platform/web/ui/session/room/RoomView";
+import { UnknownRoomView } from "hydrogen-web/src/platform/web/ui/session/room/UnknownRoomView";
+import { RoomGridView } from "hydrogen-web/src/platform/web/ui/session/RoomGridView";
+import { SessionStatusView } from "hydrogen-web/src/platform/web/ui/session/SessionStatusView";
 import { SessionView as BaseSessionView } from "hydrogen-web/src/platform/web/ui/session/SessionView";
+import { SettingsView } from "hydrogen-web/src/platform/web/ui/session/settings/SettingsView";
 
 export class SessionView extends BaseSessionView {
     constructor(value: SessionViewModel) {
         super(value);
+    }
+
+    render(t, vm) {
+        return t.div({
+            className: {
+                "SessionView": true,
+                "middle-shown": vm => !!vm.activeMiddleViewModel,
+                "right-shown": vm => !!vm.rightPanelViewModel
+            },
+        }, [
+            t.view(new SessionStatusView(vm.sessionStatusViewModel)),
+            t.view(new LeftPanelView(vm.leftPanelViewModel)),
+            t.mapView(vm => vm.activeMiddleViewModel, () => {
+                if (vm.roomGridViewModel) {
+                    return new RoomGridView(vm.roomGridViewModel, viewClassForTile);
+                } else if (vm.settingsViewModel) {
+                    return new SettingsView(vm.settingsViewModel);
+                } else if (vm.createRoomViewModel) {
+                    return new CreateRoomView(vm.createRoomViewModel);
+                } else if (vm.joinRoomViewModel) {
+                    return new JoinRoomView(vm.joinRoomViewModel);
+                } else if (vm.currentRoomViewModel) {
+                    if (vm.currentRoomViewModel.kind === "invite") {
+                        return new InviteView(vm.currentRoomViewModel);
+                    } else if (vm.currentRoomViewModel.kind === "room") {
+                        return new RoomView(vm.currentRoomViewModel, viewClassForTile);
+                    } else if (vm.currentRoomViewModel.kind === "roomBeingCreated") {
+                        return new RoomBeingCreatedView(vm.currentRoomViewModel);
+                    } else {
+                        return new UnknownRoomView(vm.currentRoomViewModel);
+                    }
+                } else {
+                    return new StaticView(t => t.div({className: "room-placeholder"}, t.h2(vm.i18n`Choose a room on the left side.`)));
+                }
+            }),
+            t.mapView(vm => vm.lightboxViewModel, lightboxViewModel => lightboxViewModel ? new LightboxView(lightboxViewModel) : null),
+            t.mapView(vm => vm.rightPanelViewModel, rightPanelViewModel => rightPanelViewModel ? new RightPanelView(rightPanelViewModel) : null)
+        ]);
     }
 }

--- a/frontend/iframe/views/SessionView.ts
+++ b/frontend/iframe/views/SessionView.ts
@@ -1,4 +1,3 @@
-import { SessionViewModel } from "hydrogen-web/src/domain/session/SessionViewModel";
 import { StaticView } from "hydrogen-web/src/platform/web/ui/general/StaticView";
 import { CreateRoomView } from "hydrogen-web/src/platform/web/ui/session/CreateRoomView";
 import { JoinRoomView } from "hydrogen-web/src/platform/web/ui/session/JoinRoomView";
@@ -13,19 +12,20 @@ import { RoomGridView } from "hydrogen-web/src/platform/web/ui/session/RoomGridV
 import { SessionStatusView } from "hydrogen-web/src/platform/web/ui/session/SessionStatusView";
 import { SessionView as BaseSessionView } from "hydrogen-web/src/platform/web/ui/session/SessionView";
 import { SettingsView } from "hydrogen-web/src/platform/web/ui/session/settings/SettingsView";
+import { SessionViewModel } from "../viewmodels/SessionViewModel";
 import { RoomView } from "./RoomView";
 
 export class SessionView extends BaseSessionView {
-    constructor(value: SessionViewModel) {
+    constructor(value?: SessionViewModel) {
         super(value);
     }
 
-    render(t, vm) {
+    render(t, vm: SessionViewModel) {
         return t.div({
             className: {
                 "SessionView": true,
-                "middle-shown": vm => !!vm.activeMiddleViewModel,
-                "right-shown": vm => !!vm.rightPanelViewModel
+                "middle-shown": (vm: SessionViewModel) => !!vm.activeMiddleViewModel,
+                "right-shown": (vm: SessionViewModel) => !!vm.rightPanelViewModel,
             },
         }, [
             t.view(new SessionStatusView(vm.sessionStatusViewModel)),

--- a/frontend/iframe/views/SessionView.ts
+++ b/frontend/iframe/views/SessionView.ts
@@ -8,12 +8,12 @@ import { viewClassForTile } from "hydrogen-web/src/platform/web/ui/session/room/
 import { InviteView } from "hydrogen-web/src/platform/web/ui/session/room/InviteView";
 import { LightboxView } from "hydrogen-web/src/platform/web/ui/session/room/LightboxView";
 import { RoomBeingCreatedView } from "hydrogen-web/src/platform/web/ui/session/room/RoomBeingCreatedView";
-import { RoomView } from "hydrogen-web/src/platform/web/ui/session/room/RoomView";
 import { UnknownRoomView } from "hydrogen-web/src/platform/web/ui/session/room/UnknownRoomView";
 import { RoomGridView } from "hydrogen-web/src/platform/web/ui/session/RoomGridView";
 import { SessionStatusView } from "hydrogen-web/src/platform/web/ui/session/SessionStatusView";
 import { SessionView as BaseSessionView } from "hydrogen-web/src/platform/web/ui/session/SessionView";
 import { SettingsView } from "hydrogen-web/src/platform/web/ui/session/settings/SettingsView";
+import { RoomView } from "./RoomView";
 
 export class SessionView extends BaseSessionView {
     constructor(value: SessionViewModel) {

--- a/frontend/iframe/views/SessionView.ts
+++ b/frontend/iframe/views/SessionView.ts
@@ -1,0 +1,8 @@
+import { SessionViewModel } from "hydrogen-web/src/domain/session/SessionViewModel";
+import { SessionView as BaseSessionView } from "hydrogen-web/src/platform/web/ui/session/SessionView";
+
+export class SessionView extends BaseSessionView {
+    constructor(value: SessionViewModel) {
+        super(value);
+    }
+}


### PR DESCRIPTION
Fixes #91

This PR fixes the following issues with single-room mode:

1. #91 
2. In non-small screens, single-room mode was not functional, since user still had access to list of rooms.
3. User could not access session picker when in single-room mode.

This PR implements the following changes, which fix all above issues.

When in single room mode:

1. Hide the left panel completely
2. Add a Settings entry to the options menu of the room
3. Closing the Settings screen navigates to configured `roomId`
4. Closing the Room (timeline) screen navigates to session picker

## Screen captures
### Small screen

https://user-images.githubusercontent.com/550401/209191336-4fa55c9e-2ddd-4bc7-aac8-1beb8776a179.mov

### Non-small screen
https://user-images.githubusercontent.com/550401/209191349-b23a3f65-9afe-47fc-a8a3-890efe508b4f.mov


