### PR TITLE
Delete logout cookie

### DIFF
--- a/frontend/logout.ts
+++ b/frontend/logout.ts
@@ -8,12 +8,12 @@ window.addEventListener('DOMContentLoaded', () => {
     }
 
     console.log("Logging out all chatrix sessions");
-    logoutAndDeleteData().catch(error => console.log(error)).finally(() => {
+    logoutAndDeleteData().then(() => {
         // Logout has been done and data has been deleted.
         // We can now expire the logout cookie.
         const now = (new Date).toUTCString();
         document.cookie = `${logoutCookieName}=false; expires=${now};path=/;`;
-    });
+    }).catch(error => console.log(error));
 });
 
 async function logoutAndDeleteData() {

--- a/frontend/logout.ts
+++ b/frontend/logout.ts
@@ -8,7 +8,12 @@ window.addEventListener('DOMContentLoaded', () => {
     }
 
     console.log("Logging out all chatrix sessions");
-    logoutAndDeleteData().catch(error => console.log(error));
+    logoutAndDeleteData().catch(error => console.log(error)).finally(() => {
+        // Logout has been done and data has been deleted.
+        // We can now expire the logout cookie.
+        const now = (new Date).toUTCString();
+        document.cookie = `${logoutCookieName}=false; expires=${now};path=/;`;
+    });
 });
 
 async function logoutAndDeleteData() {

--- a/frontend/logout.ts
+++ b/frontend/logout.ts
@@ -13,7 +13,7 @@ window.addEventListener('DOMContentLoaded', () => {
         // We can now expire the logout cookie.
         const now = (new Date).toUTCString();
         document.cookie = `${logoutCookieName}=false; expires=${now};path=/;`;
-    }).catch(error => console.log(error));
+    }).catch(error => console.error(error));
 });
 
 async function logoutAndDeleteData() {
@@ -67,7 +67,7 @@ async function logoutSession(session) {
     });
 
     promise.catch(error => {
-        console.log(`Failed to logout chatrix session. deviceId: ${session.deviceId}`, error);
+        console.error(`Failed to logout chatrix session. deviceId: ${session.deviceId}`);
     });
 
     return promise;

--- a/frontend/logout.ts
+++ b/frontend/logout.ts
@@ -58,6 +58,12 @@ async function logoutSession(session) {
         headers: {
             'Authorization': 'Bearer ' + session.accessToken,
         },
+    }).then((response) => {
+        // Fetch considers 403 and 404 to be a success but to us, it's a failure.
+        if (!response.ok) {
+            throw response;
+        }
+        return response;
     });
 
     promise.catch(error => {

--- a/src/Sessions/logout.php
+++ b/src/Sessions/logout.php
@@ -2,6 +2,9 @@
 
 namespace Automattic\Chatrix\Sessions;
 
+use const Automattic\Chatrix\LOGOUT_COOKIE_NAME;
+use const Automattic\Chatrix\SCRIPT_HANDLE_LOGOUT;
+
 function init_logout() {
 	// Set a cookie when user logs out.
 	add_action(
@@ -9,7 +12,10 @@ function init_logout() {
 		function () {
 			// Expire in 10 minutes.
 			$expiration = time() + ( 10 * 60 );
-			setcookie( 'chatrix-logout', 'true', $expiration, COOKIEPATH, COOKIE_DOMAIN );
+			setcookie( LOGOUT_COOKIE_NAME, 'true', $expiration, COOKIEPATH, COOKIE_DOMAIN );
+
+			// Enqueue the script that will perform logout on the client.
+			wp_enqueue_script( SCRIPT_HANDLE_LOGOUT );
 		}
 	);
 }

--- a/src/Sessions/logout.php
+++ b/src/Sessions/logout.php
@@ -3,7 +3,6 @@
 namespace Automattic\Chatrix\Sessions;
 
 use const Automattic\Chatrix\LOGOUT_COOKIE_NAME;
-use const Automattic\Chatrix\SCRIPT_HANDLE_LOGOUT;
 
 function init_logout() {
 	// Set a cookie when user logs out.
@@ -13,9 +12,6 @@ function init_logout() {
 			// Expire in 10 minutes.
 			$expiration = time() + ( 10 * 60 );
 			setcookie( LOGOUT_COOKIE_NAME, 'true', $expiration, COOKIEPATH, COOKIE_DOMAIN );
-
-			// Enqueue the script that will perform logout on the client.
-			wp_enqueue_script( SCRIPT_HANDLE_LOGOUT );
 		}
 	);
 }

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -10,6 +10,7 @@ const SCRIPT_HANDLE_CONFIG = 'chatrix-config';
 const SCRIPT_HANDLE_APP    = 'chatrix-app';
 const SCRIPT_HANDLE_LOGOUT = 'chatrix-logout';
 const CONFIG_VARIABLE      = 'ChatrixConfig';
+const LOGOUT_COOKIE_NAME   = 'chatrix-logout';
 
 function main() {
 	init_logout();
@@ -51,7 +52,11 @@ function register_scripts() {
 					automattic_chatrix_version(),
 					false
 				);
-				wp_enqueue_script( SCRIPT_HANDLE_LOGOUT );
+
+				// Enqueue the logout script only if the logout cookie is set.
+				if ( isset( $_COOKIE[ LOGOUT_COOKIE_NAME ] ) ) {
+					wp_enqueue_script( SCRIPT_HANDLE_LOGOUT );
+				}
 			}
 		}
 	);

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -53,10 +53,7 @@ function register_scripts() {
 					false
 				);
 
-				// Enqueue the logout script only if the logout cookie is set.
-				if ( isset( $_COOKIE[ LOGOUT_COOKIE_NAME ] ) ) {
-					wp_enqueue_script( SCRIPT_HANDLE_LOGOUT );
-				}
+				wp_enqueue_script( SCRIPT_HANDLE_LOGOUT );
 			}
 		}
 	);


### PR DESCRIPTION
When the user logs out of WordPress, a `chatrix-logout` cookie is set, which will result in the `logout.ts` script runing, which logs out matrix sessions, and deletes all chatrix data in the browser.

However, this cookie wasn't beeing expired after sessions had been logged out, which would result in the script running on all page loads (until the cookie expires). This PR fixes that by expiring the cookie once sessions have been logged out and data deleted.

~Addiitionally, [as suggested by @ashfame](https://github.com/Automattic/chatrix/pull/150#pullrequestreview-1236336813), the logout script is now only being enqueued when the `chatrix-logout` cookie exists.~