### PR TITLE
Height unit selector

### DIFF
--- a/frontend/block/editor.scss
+++ b/frontend/block/editor.scss
@@ -17,6 +17,10 @@
       align-items: center;
       justify-content: center;
 
+      & > input {
+        width: 75%;
+      }
+
       & > span {
         margin-left: 5px;
       }

--- a/frontend/block/inspector/StylePanel.tsx
+++ b/frontend/block/inspector/StylePanel.tsx
@@ -1,6 +1,7 @@
 import { PanelBody, PanelRow, TextControl } from "@wordpress/components";
 import { WPElement } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
+import { Unit } from "../../components/block";
 import TextControlWithUnit from "./TextControlWithUnit";
 
 export default function StylePanel({ attributes, setAttributes }): WPElement {
@@ -14,6 +15,7 @@ export default function StylePanel({ attributes, setAttributes }): WPElement {
                     label={__("height", "chatrix")}
                     value={attributes.height.value}
                     unit={attributes.height.unit}
+                    units={[Unit.px, Unit["%"], Unit.vh, Unit.vw, Unit.vmax, Unit.vmin]}
                     onChange={(value, unit) => {
                         setAttributes({ height: { value: value, unit: unit } });
                     }}
@@ -24,6 +26,7 @@ export default function StylePanel({ attributes, setAttributes }): WPElement {
                     label={__("border width", "chatrix")}
                     value={attributes.borderWidth.value}
                     unit={attributes.borderWidth.unit}
+                    units={[Unit.px]}
                     onChange={(value, unit) => {
                         setAttributes({ borderWidth: { value: value, unit: unit } });
                     }}
@@ -52,6 +55,7 @@ export default function StylePanel({ attributes, setAttributes }): WPElement {
                     label={__("border radius", "chatrix")}
                     value={attributes.borderRadius.value}
                     unit={attributes.borderRadius.unit}
+                    units={[Unit.px]}
                     onChange={(value, unit) => {
                         setAttributes({ borderRadius: { value: value, unit: unit } });
                     }}

--- a/frontend/block/inspector/StylePanel.tsx
+++ b/frontend/block/inspector/StylePanel.tsx
@@ -14,8 +14,8 @@ export default function StylePanel({ attributes, setAttributes }): WPElement {
                     label={__("height", "chatrix")}
                     value={attributes.height.value}
                     unit={attributes.height.unit}
-                    onChange={(value) => {
-                        setAttributes({ height: { value: value, unit: "px" } });
+                    onChange={(value, unit) => {
+                        setAttributes({ height: { value: value, unit: unit } });
                     }}
                 />
             </PanelRow>
@@ -24,8 +24,8 @@ export default function StylePanel({ attributes, setAttributes }): WPElement {
                     label={__("border width", "chatrix")}
                     value={attributes.borderWidth.value}
                     unit={attributes.borderWidth.unit}
-                    onChange={(value) => {
-                        setAttributes({ borderWidth: { value: value, unit: "px" } });
+                    onChange={(value, unit) => {
+                        setAttributes({ borderWidth: { value: value, unit: unit } });
                     }}
                 />
             </PanelRow>
@@ -52,8 +52,8 @@ export default function StylePanel({ attributes, setAttributes }): WPElement {
                     label={__("border radius", "chatrix")}
                     value={attributes.borderRadius.value}
                     unit={attributes.borderRadius.unit}
-                    onChange={(value) => {
-                        setAttributes({ borderRadius: { value: value, unit: "px" } });
+                    onChange={(value, unit) => {
+                        setAttributes({ borderRadius: { value: value, unit: unit } });
                     }}
                 />
             </PanelRow>

--- a/frontend/block/inspector/StylePanel.tsx
+++ b/frontend/block/inspector/StylePanel.tsx
@@ -26,7 +26,7 @@ export default function StylePanel({ attributes, setAttributes }): WPElement {
                     label={__("border width", "chatrix")}
                     value={attributes.borderWidth.value}
                     unit={attributes.borderWidth.unit}
-                    units={[Unit.px]}
+                    units={[Unit.px, Unit.em, Unit.rem]}
                     onChange={(value, unit) => {
                         setAttributes({ borderWidth: { value: value, unit: unit } });
                     }}
@@ -55,7 +55,7 @@ export default function StylePanel({ attributes, setAttributes }): WPElement {
                     label={__("border radius", "chatrix")}
                     value={attributes.borderRadius.value}
                     unit={attributes.borderRadius.unit}
-                    units={[Unit.px]}
+                    units={[Unit.px, Unit.em, Unit.rem]}
                     onChange={(value, unit) => {
                         setAttributes({ borderRadius: { value: value, unit: unit } });
                     }}

--- a/frontend/block/inspector/TextControlWithUnit.tsx
+++ b/frontend/block/inspector/TextControlWithUnit.tsx
@@ -2,6 +2,7 @@ import { BaseControl } from "@wordpress/components";
 import { useInstanceId } from "@wordpress/compose";
 import { forwardRef, useState } from "@wordpress/element";
 import type { ChangeEvent, FormEvent, ForwardedRef } from 'react';
+import { Unit } from "../../components/block";
 
 interface Props {
     value: number
@@ -22,7 +23,7 @@ export default TextControlWithUnit;
 function UnforwardedTextControlWithUnit(props: Props, ref: ForwardedRef<HTMLInputElement>) {
     const instanceId = useInstanceId(TextControlWithUnit);
     const id = `inspector-text-control-${instanceId}`;
-    const units = ["px"];
+    const units = Object.values(Unit);
 
     const [state, setState] = useState<State>({
         value: props.value,

--- a/frontend/block/inspector/TextControlWithUnit.tsx
+++ b/frontend/block/inspector/TextControlWithUnit.tsx
@@ -7,6 +7,7 @@ import { Unit } from "../../components/block";
 interface Props {
     value: number
     unit: string
+    units: Unit[],
     onChange: (value: number, unit: string) => any
     label: string
     help?: string
@@ -23,7 +24,6 @@ export default TextControlWithUnit;
 function UnforwardedTextControlWithUnit(props: Props, ref: ForwardedRef<HTMLInputElement>) {
     const instanceId = useInstanceId(TextControlWithUnit);
     const id = `inspector-text-control-${instanceId}`;
-    const units = Object.values(Unit);
 
     const [state, setState] = useState<State>({
         value: props.value,
@@ -72,7 +72,7 @@ function UnforwardedTextControlWithUnit(props: Props, ref: ForwardedRef<HTMLInpu
                         ref={ref}
                     />
                     <select value={state.unit} onChange={onChangeUnit}>
-                        {units.map(unit => <option value={unit} key={unit}>{unit}</option>)}
+                        {props.units.map(unit => <option value={unit} key={unit}>{unit}</option>)}
                     </select>
                 </span>
             </BaseControl>

--- a/frontend/block/inspector/TextControlWithUnit.tsx
+++ b/frontend/block/inspector/TextControlWithUnit.tsx
@@ -1,14 +1,19 @@
 import { BaseControl } from "@wordpress/components";
 import { useInstanceId } from "@wordpress/compose";
-import { forwardRef } from "@wordpress/element";
-import type { ChangeEvent, ForwardedRef } from 'react';
+import { forwardRef, useState } from "@wordpress/element";
+import type { ChangeEvent, FormEvent, ForwardedRef } from 'react';
 
 interface Props {
     value: number
     unit: string
-    onChange: any
+    onChange: (value: number, unit: string) => any
     label: string
     help?: string
+}
+
+interface State {
+    value: number;
+    unit: string;
 }
 
 export const TextControlWithUnit = forwardRef(UnforwardedTextControlWithUnit);
@@ -17,7 +22,36 @@ export default TextControlWithUnit;
 function UnforwardedTextControlWithUnit(props: Props, ref: ForwardedRef<HTMLInputElement>) {
     const instanceId = useInstanceId(TextControlWithUnit);
     const id = `inspector-text-control-${instanceId}`;
-    const onChangeValue = (event: ChangeEvent<HTMLInputElement>) => props.onChange(event.target.value);
+    const units = ["px"];
+
+    const [state, setState] = useState<State>({
+        value: props.value,
+        unit: props.unit,
+    });
+
+    if (props !== state) {
+        setState(props);
+    }
+
+    const onChangeValue = (event: ChangeEvent<HTMLInputElement>) => {
+        const target = event.target as HTMLInputElement;
+        const value = +target.value;
+        setState({
+            ...state,
+            value: value,
+        });
+        props.onChange(value, state.unit);
+    };
+
+    const onChangeUnit = (event: FormEvent<HTMLSelectElement>) => {
+        const target = event.target as HTMLSelectElement;
+        const unit = target.value;
+        setState({
+            ...state,
+            unit: unit,
+        });
+        props.onChange(state.value, unit);
+    };
 
     return (
         <div className={"chatrix-text-control-with-unit"}>
@@ -31,12 +65,14 @@ function UnforwardedTextControlWithUnit(props: Props, ref: ForwardedRef<HTMLInpu
                         className="components-text-control__input"
                         type={"text"}
                         id={id}
-                        value={props.value}
+                        value={state.value}
                         onChange={onChangeValue}
                         aria-describedby={!!props.help ? id + '__help' : undefined}
                         ref={ref}
                     />
-                    <span>{props.unit}</span>
+                    <select value={state.unit} onChange={onChangeUnit}>
+                        {units.map(unit => <option value={unit} key={unit}>{unit}</option>)}
+                    </select>
                 </span>
             </BaseControl>
         </div>

--- a/frontend/components/block/attributes.ts
+++ b/frontend/components/block/attributes.ts
@@ -1,3 +1,5 @@
+import { Unit, ValueWithUnit } from "./unit";
+
 interface Attributes {
     defaultHomeserver?: string,
     roomId?: string,
@@ -18,37 +20,6 @@ export function parseAttributes(attributes): Attributes {
         borderStyle: attributes.borderStyle,
         borderColor: attributes.borderColor,
     };
-}
-
-enum Unit {
-    px = "px",
-}
-
-function unitFromString(value: string): Unit | undefined {
-    switch (value) {
-        case Unit.px:
-            return Unit.px;
-    }
-    return undefined;
-}
-
-class ValueWithUnit {
-    protected readonly value: number;
-    protected readonly unit?: Unit;
-
-    constructor(value: number, unit: Unit | string) {
-        this.value = value;
-
-        if (typeof unit === "string") {
-            this.unit = unitFromString(unit);
-        } else {
-            this.unit = unit;
-        }
-    }
-
-    public toString(): string {
-        return this.value && this.unit ? `${this.value}${this.unit}` : '';
-    }
 }
 
 class Height extends ValueWithUnit {

--- a/frontend/components/block/index.tsx
+++ b/frontend/components/block/index.tsx
@@ -1,2 +1,3 @@
 export { Block, type BlockProps } from "./block";
 export { parseAttributes } from "./attributes";
+export { Unit, ValueWithUnit } from "./unit";

--- a/frontend/components/block/unit.ts
+++ b/frontend/components/block/unit.ts
@@ -2,23 +2,19 @@ export enum Unit {
     px = "px",
 }
 
-function unitFromString(value: string): Unit | undefined {
-    switch (value) {
-        case Unit.px:
-            return Unit.px;
-    }
-    return undefined;
-}
-
 export class ValueWithUnit {
     protected readonly value: number;
     protected readonly unit?: Unit;
 
-    constructor(value: number, unit: Unit | string) {
-        this.value = value;
+    constructor(value: number | string, unit: Unit | string) {
+        if (typeof value === "string") {
+            this.value = +value;
+        } else {
+            this.value = value;
+        }
 
         if (typeof unit === "string") {
-            this.unit = unitFromString(unit);
+            this.unit = Unit[unit];
         } else {
             this.unit = unit;
         }

--- a/frontend/components/block/unit.ts
+++ b/frontend/components/block/unit.ts
@@ -1,8 +1,10 @@
 export enum Unit {
     px = "px",
     "%" = "%",
-    em = "em",
-    rem = "rem",
+    vh = "vh",
+    vw = "vw",
+    vmax = "vmax",
+    vmin = "vmin",
 }
 
 export class ValueWithUnit {

--- a/frontend/components/block/unit.ts
+++ b/frontend/components/block/unit.ts
@@ -1,5 +1,8 @@
 export enum Unit {
     px = "px",
+    "%" = "%",
+    em = "em",
+    rem = "rem",
 }
 
 export class ValueWithUnit {

--- a/frontend/components/block/unit.ts
+++ b/frontend/components/block/unit.ts
@@ -5,6 +5,8 @@ export enum Unit {
     vw = "vw",
     vmax = "vmax",
     vmin = "vmin",
+    em = "em",
+    rem = "rem",
 }
 
 export class ValueWithUnit {

--- a/frontend/components/block/unit.ts
+++ b/frontend/components/block/unit.ts
@@ -1,0 +1,30 @@
+export enum Unit {
+    px = "px",
+}
+
+function unitFromString(value: string): Unit | undefined {
+    switch (value) {
+        case Unit.px:
+            return Unit.px;
+    }
+    return undefined;
+}
+
+export class ValueWithUnit {
+    protected readonly value: number;
+    protected readonly unit?: Unit;
+
+    constructor(value: number, unit: Unit | string) {
+        this.value = value;
+
+        if (typeof unit === "string") {
+            this.unit = unitFromString(unit);
+        } else {
+            this.unit = unit;
+        }
+    }
+
+    public toString(): string {
+        return this.value && this.unit ? `${this.value}${this.unit}` : '';
+    }
+}


### PR DESCRIPTION
Fixes #137

This PR makes it possible to change the unit of fields, as opposed to the unit being hardcoded to `px`.

## Screen capture
<img width="276" alt="Screenshot 2023-01-11 at 15 28 34" src="https://user-images.githubusercontent.com/550401/211846548-83a4bc76-f873-4368-a7c6-af1848eb048a.png">


