### PR TITLE
specify development mode when instantiating Platform

### DIFF
--- a/frontend/iframe/main.ts
+++ b/frontend/iframe/main.ts
@@ -29,6 +29,9 @@ export class Main {
                 bugReportEndpointUrl: null,
                 ...ConfigFactory.fromQueryParams(),
             },
+            options: {
+                development: import.meta.env.DEV,
+            },
         });
 
         this._navigation = createNavigation();


### PR DESCRIPTION
This change enables the console logger that I was mentioning earlier. As per [docs](https://vitejs.dev/guide/env-and-mode.html), by default dev mode is true and with vite build its false, so this change should be sufficient for enabling it on local machines but not production builds.

@psrpinto Any quick way of testing this?