### PR TITLE
Wait until the page is loaded before loading Chatrix

### DIFF
--- a/frontend/block/view.ts
+++ b/frontend/block/view.ts
@@ -9,7 +9,7 @@ declare global {
     }
 }
 
-window.addEventListener('DOMContentLoaded', () => {
+window.addEventListener('load', () => {
     const config = window.ChatrixBlockConfig;
     if (!config) {
         throw "ChatrixBlockConfig is not defined";


### PR DESCRIPTION
Through trial and error I determined that on a heavier page like https://make.wordpress.org/polyglots/ the block is not loaded unless you make it load after the `load` event.