### PR TITLE
Only output the logout JS when the cookie is present

### DIFF
--- a/src/plugin.php
+++ b/src/plugin.php
@@ -44,7 +44,7 @@ function register_scripts() {
 				true
 			);
 
-			if ( ! is_user_logged_in() ) {
+			if ( ! is_user_logged_in() && isset( $_COOKIE[ LOGOUT_COOKIE_NAME ] ) ) {
 				wp_register_script(
 					SCRIPT_HANDLE_LOGOUT,
 					root_url() . '/logout.iife.js',

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -44,7 +44,10 @@ function register_scripts() {
 				true
 			);
 
-			if ( ! is_user_logged_in() && ( defined( 'WP_CACHE' ) || isset( $_COOKIE[ LOGOUT_COOKIE_NAME ] ) ) ) {
+			// filter 'chatrix_load_logout_script' exists to limit when logout script is loaded.
+			// possible optimisation to limit only when the logout cookie is set but can only do so when no page caching is involved for the page
+			// add_filter( 'chatrix_load_logout_script', function() { return isset( $_COOKIE[ \Automattic\Chatrix\LOGOUT_COOKIE_NAME ] ); } );
+			if ( ! is_user_logged_in() && apply_filters( 'chatrix_load_logout_script', true ) ) {
 				wp_register_script(
 					SCRIPT_HANDLE_LOGOUT,
 					root_url() . '/logout.iife.js',

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -45,8 +45,9 @@ function register_scripts() {
 			);
 
 			// filter 'chatrix_load_logout_script' exists to limit when logout script is loaded.
-			// possible optimisation to limit only when the logout cookie is set but can only do so when no page caching is involved for the page
+			// possible optimisation example:
 			// add_filter( 'chatrix_load_logout_script', function() { return isset( $_COOKIE[ \Automattic\Chatrix\LOGOUT_COOKIE_NAME ] ); } );
+			// to limit it when the logout cookie is set but can only do so when no page caching is involved for the page.
 			if ( ! is_user_logged_in() && apply_filters( 'chatrix_load_logout_script', true ) ) {
 				wp_register_script(
 					SCRIPT_HANDLE_LOGOUT,

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -44,7 +44,7 @@ function register_scripts() {
 				true
 			);
 
-			if ( ! is_user_logged_in() && isset( $_COOKIE[ LOGOUT_COOKIE_NAME ] ) ) {
+			if ( ! is_user_logged_in() && ( defined( 'WP_CACHE' ) || isset( $_COOKIE[ LOGOUT_COOKIE_NAME ] ) ) ) {
 				wp_register_script(
 					SCRIPT_HANDLE_LOGOUT,
 					root_url() . '/logout.iife.js',


### PR DESCRIPTION
Fixes #164

This adds a PHP check for the cookie so that the logout JS code is not printed for every user.