### PR TITLE
Using setTimeout loads the iframe more reliably

### DIFF
--- a/frontend/app.ts
+++ b/frontend/app.ts
@@ -19,9 +19,7 @@ export function renderBlock(containerId: string, props: BlockProps) {
     };
 
     const element = createElement(Block, blockProps);
-    setTimeout( function() {
-        render(element, document.getElementById(containerId));
-    }, 1 );
+    render(element, document.getElementById(containerId));
 }
 
 export type PopupProps = Omit<BasePopupProps, "iframeUrl">;

--- a/frontend/app.ts
+++ b/frontend/app.ts
@@ -19,7 +19,9 @@ export function renderBlock(containerId: string, props: BlockProps) {
     };
 
     const element = createElement(Block, blockProps);
-    render(element, document.getElementById(containerId));
+    setTimeout( function() {
+        render(element, document.getElementById(containerId));
+    }, 1 );
 }
 
 export type PopupProps = Omit<BasePopupProps, "iframeUrl">;

--- a/frontend/block/view.ts
+++ b/frontend/block/view.ts
@@ -25,5 +25,6 @@ window.addEventListener('DOMContentLoaded', () => {
         attributes: config.attributes,
     };
 
-    renderBlock(containerId, props);
+    // See https://github.com/Automattic/chatrix/issues/161 for why we use a timeout here.
+    setTimeout( () => renderBlock(containerId, props), 1 );
 });

--- a/frontend/block/view.ts
+++ b/frontend/block/view.ts
@@ -9,7 +9,7 @@ declare global {
     }
 }
 
-window.addEventListener('load', () => {
+window.addEventListener('DOMContentLoaded', () => {
     const config = window.ChatrixBlockConfig;
     if (!config) {
         throw "ChatrixBlockConfig is not defined";


### PR DESCRIPTION
Revert #160 and fix #161.

While still not very elegant, wrapping the React `render` call in a `setTimeout` makes Chatrix load more reliably.