### PR TITLE
Multiple blocks on the same page

### DIFF
--- a/frontend/app.ts
+++ b/frontend/app.ts
@@ -12,26 +12,34 @@ declare global {
 
 export type BlockProps = Omit<BaseBlockProps, "iframeUrl">;
 
-export function renderBlock(containerId: string, props: BlockProps) {
+export function renderBlock(containerElement: HTMLElement | null, props: BlockProps) {
+    if (!containerElement) {
+        return;
+    }
+
     const blockProps: BaseBlockProps = {
         ...props,
         iframeUrl: getIframeUrl(),
     };
 
     const element = createElement(Block, blockProps);
-    render(element, document.getElementById(containerId));
+    render(element, containerElement);
 }
 
 export type PopupProps = Omit<BasePopupProps, "iframeUrl">;
 
-export function renderPopup(containerId: string, props: PopupProps) {
+export function renderPopup(containerElement: HTMLElement | null, props: PopupProps) {
+    if (!containerElement) {
+        return;
+    }
+
     const popupProps: BasePopupProps = {
         ...props,
         iframeUrl: getIframeUrl(),
     };
 
     const element = createElement(Popup, popupProps);
-    render(element, document.getElementById(containerId));
+    render(element, containerElement);
 }
 
 export function getIframeUrl(): URL {

--- a/frontend/app.ts
+++ b/frontend/app.ts
@@ -12,11 +12,7 @@ declare global {
 
 export type BlockProps = Omit<BaseBlockProps, "iframeUrl">;
 
-export function renderBlock(containerElement: HTMLElement | null, props: BlockProps) {
-    if (!containerElement) {
-        return;
-    }
-
+export function renderBlock(containerElement: HTMLElement, props: BlockProps) {
     const blockProps: BaseBlockProps = {
         ...props,
         iframeUrl: getIframeUrl(),
@@ -28,11 +24,7 @@ export function renderBlock(containerElement: HTMLElement | null, props: BlockPr
 
 export type PopupProps = Omit<BasePopupProps, "iframeUrl">;
 
-export function renderPopup(containerElement: HTMLElement | null, props: PopupProps) {
-    if (!containerElement) {
-        return;
-    }
-
+export function renderPopup(containerElement: HTMLElement, props: PopupProps) {
     const popupProps: BasePopupProps = {
         ...props,
         iframeUrl: getIframeUrl(),

--- a/frontend/block/edit.tsx
+++ b/frontend/block/edit.tsx
@@ -24,29 +24,29 @@ export default function Edit(props: Props): WPElement {
     return (
         <>
             <InspectorControls attributes={attributes} setAttributes={setAttributes}/>
-            <div {...useBlockProps()}>
-                <ResizableBox
-                    size={{
-                        width: "100%",
-                        height: parsedAttributes.height ? parsedAttributes.height.toString() : "600px",
-                    }}
-                    enable={{
-                        top: false,
-                        right: false,
-                        bottom: true,
-                        left: false,
-                        topRight: false,
-                        bottomRight: false,
-                        bottomLeft: false,
-                        topLeft: false,
-                    }}
-                    onResizeStop={(_event, _direction, elt) => {
-                        setAttributes({ height: { value: elt.clientHeight, unit: "px" } });
-                    }}
-                >
+            <ResizableBox
+                size={{
+                    width: "100%",
+                    height: parsedAttributes.height ? parsedAttributes.height.toString() : "600px",
+                }}
+                enable={{
+                    top: false,
+                    right: false,
+                    bottom: true,
+                    left: false,
+                    topRight: false,
+                    bottomRight: false,
+                    bottomLeft: false,
+                    topLeft: false,
+                }}
+                onResizeStop={(_event, _direction, elt) => {
+                    setAttributes({ height: { value: elt.clientHeight, unit: "px" } });
+                }}
+            >
+                <div {...useBlockProps()}>
                     <Block {...blockProps}/>
-                </ResizableBox>
-            </div>
+                </div>
+            </ResizableBox>
         </>
     );
 }

--- a/frontend/block/view.ts
+++ b/frontend/block/view.ts
@@ -34,7 +34,7 @@ async function renderAllBlocks() {
         attributes: config.attributes,
     };
 
-    renderBlock(containerId, props);
+    renderBlock(document.getElementById(containerId), props);
 }
 
 async function introduceDelayInMilliseconds(delay: number) {

--- a/frontend/block/view.ts
+++ b/frontend/block/view.ts
@@ -24,17 +24,17 @@ async function renderAllBlocks() {
         throw "ChatrixBlockConfig is not defined";
     }
 
-    const containerId = config.containerId;
-    const container = document.getElementById(containerId);
-    if (!container) {
-        throw `element with id ${containerId} was not found`;
-    }
-
     const props: BlockProps = {
         attributes: config.attributes,
     };
 
-    renderBlock(document.getElementById(containerId), props);
+    const containers = <HTMLCollectionOf<HTMLElement>>document.getElementsByClassName('wp-block-automattic-chatrix');
+    for (const container of containers) {
+        renderBlock(container, props);
+
+        // TODO: Support multiple blocks on the same page.
+        break;
+    }
 }
 
 async function introduceDelayInMilliseconds(delay: number) {

--- a/frontend/block/view.ts
+++ b/frontend/block/view.ts
@@ -1,13 +1,5 @@
 import { BlockProps, renderBlock } from "../app";
 
-declare global {
-    interface Window {
-        ChatrixBlockConfig: {
-            attributes: object,
-        };
-    }
-}
-
 window.addEventListener('DOMContentLoaded', () => {
     renderAllBlocks().catch(error => {
         console.error(error);
@@ -18,22 +10,40 @@ async function renderAllBlocks() {
     // See https://github.com/Automattic/chatrix/issues/161 for why we introduce a delay here.
     await introduceDelayInMilliseconds(1);
 
-    const config = window.ChatrixBlockConfig;
-    if (!config) {
-        throw "ChatrixBlockConfig is not defined";
-    }
-
-    const props: BlockProps = {
-        attributes: config.attributes,
-    };
-
     const containers = <HTMLCollectionOf<HTMLElement>>document.getElementsByClassName('wp-block-automattic-chatrix');
     for (const container of containers) {
+        const config = getConfigFromDataElement(container);
+        const props: BlockProps = {
+            attributes: config.attributes,
+        };
+
         renderBlock(container, props);
 
         // TODO: Support multiple blocks on the same page.
         break;
     }
+}
+
+/**
+ * The container element has a single <span> child that contains the config as a data-attribute.
+ * This function parses that data-attribute into an object.
+ */
+function getConfigFromDataElement(container: HTMLElement): BlockConfig {
+    const dataElement = container.getElementsByTagName('span').item(0);
+    if (!dataElement) {
+        throw "Data element for chatrix block was not found";
+    }
+
+    const dataString = decodeURIComponent(dataElement.dataset?.chatrixBlockConfig ?? '');
+    if (dataString === '') {
+        throw "Data attribute for chatrix block was not found, or is empty";
+    }
+
+    return JSON.parse(dataString);
+}
+
+interface BlockConfig {
+    attributes: object,
 }
 
 async function introduceDelayInMilliseconds(delay: number) {

--- a/frontend/block/view.ts
+++ b/frontend/block/view.ts
@@ -3,7 +3,6 @@ import { BlockProps, renderBlock } from "../app";
 declare global {
     interface Window {
         ChatrixBlockConfig: {
-            containerId: string,
             attributes: object,
         };
     }

--- a/frontend/block/view.ts
+++ b/frontend/block/view.ts
@@ -22,7 +22,7 @@ async function renderAllBlocks() {
 }
 
 /**
- * The container element has a single <span> child that contains the config as a data-attribute.
+ * The container element has a data-attribute that contains the config as encoded data.
  * This function parses that data-attribute into an object.
  */
 function getConfigFromDataAttribute(container: HTMLElement): BlockConfig {

--- a/frontend/block/view.ts
+++ b/frontend/block/view.ts
@@ -12,7 +12,7 @@ async function renderAllBlocks() {
 
     const containers = <HTMLCollectionOf<HTMLElement>>document.getElementsByClassName('wp-block-automattic-chatrix');
     for (const container of containers) {
-        const config = getConfigFromDataElement(container);
+        const config = getConfigFromDataAttribute(container);
         const props: BlockProps = {
             attributes: config.attributes,
         };
@@ -25,13 +25,8 @@ async function renderAllBlocks() {
  * The container element has a single <span> child that contains the config as a data-attribute.
  * This function parses that data-attribute into an object.
  */
-function getConfigFromDataElement(container: HTMLElement): BlockConfig {
-    const dataElement = container.getElementsByTagName('span').item(0);
-    if (!dataElement) {
-        throw "Data element for chatrix block was not found";
-    }
-
-    const dataString = decodeURIComponent(dataElement.dataset?.chatrixBlockConfig ?? '');
+function getConfigFromDataAttribute(container: HTMLElement): BlockConfig {
+    const dataString = decodeURIComponent(container.dataset?.chatrixBlockConfig ?? '');
     if (dataString === '') {
         throw "Data attribute for chatrix block was not found, or is empty";
     }

--- a/frontend/block/view.ts
+++ b/frontend/block/view.ts
@@ -16,6 +16,9 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 
 async function renderAllBlocks() {
+    // See https://github.com/Automattic/chatrix/issues/161 for why we introduce a delay here.
+    await introduceDelayInMilliseconds(1);
+
     const config = window.ChatrixBlockConfig;
     if (!config) {
         throw "ChatrixBlockConfig is not defined";
@@ -31,6 +34,9 @@ async function renderAllBlocks() {
         attributes: config.attributes,
     };
 
-    // See https://github.com/Automattic/chatrix/issues/161 for why we use a timeout here.
-    setTimeout( () => renderBlock(containerId, props), 1 );
+    renderBlock(containerId, props);
+}
+
+async function introduceDelayInMilliseconds(delay: number) {
+    return new Promise(resolve => setTimeout(resolve, delay));
 }

--- a/frontend/block/view.ts
+++ b/frontend/block/view.ts
@@ -10,6 +10,12 @@ declare global {
 }
 
 window.addEventListener('DOMContentLoaded', () => {
+    renderAllBlocks().catch(error => {
+        console.error(error);
+    });
+});
+
+async function renderAllBlocks() {
     const config = window.ChatrixBlockConfig;
     if (!config) {
         throw "ChatrixBlockConfig is not defined";
@@ -27,4 +33,4 @@ window.addEventListener('DOMContentLoaded', () => {
 
     // See https://github.com/Automattic/chatrix/issues/161 for why we use a timeout here.
     setTimeout( () => renderBlock(containerId, props), 1 );
-});
+}

--- a/frontend/block/view.ts
+++ b/frontend/block/view.ts
@@ -18,9 +18,6 @@ async function renderAllBlocks() {
         };
 
         renderBlock(container, props);
-
-        // TODO: Support multiple blocks on the same page.
-        break;
     }
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,14 +34,14 @@
             iframeUrl: window.origin,
         };
 
-        renderBlock("root-block", {
+        renderBlock(document.getElementById("root-block"), {
             attributes: {
                 defaultHomeserver: env.VITE_HOMESERVER,
                 roomId: env.VITE_ROOM_ID,
             }
         });
 
-        renderPopup("root-popup", {
+        renderPopup(document.getElementById("root-popup"), {
             defaultHomeserver: env.VITE_HOMESERVER,
             roomId: env.VITE_ROOM_ID,
         });

--- a/src/Block/block.php
+++ b/src/Block/block.php
@@ -28,13 +28,10 @@ function register() {
 }
 
 function render( array $attributes ): string {
-	$handle       = 'chatrix-block-config';
-	$container_id = 'wp-block-automattic-chatrix-container';
-
+	$handle    = 'chatrix-block-config';
 	$json_data = wp_json_encode(
 		array(
-			'containerId' => $container_id,
-			'attributes'  => $attributes,
+			'attributes' => $attributes,
 		)
 	);
 
@@ -44,7 +41,7 @@ function render( array $attributes ): string {
 
 	ob_start();
 	?>
-	<div <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?> id="<?php echo esc_attr( $container_id ); ?>">
+	<div <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
 		<?php // Iframe will be rendered here. ?>
 	</div>
 	<?php

--- a/src/Block/block.php
+++ b/src/Block/block.php
@@ -28,26 +28,21 @@ function register() {
 }
 
 function render( array $attributes ): string {
-	$handle    = 'chatrix-block-config';
 	$json_data = wp_json_encode(
 		array(
 			'attributes' => $attributes,
 		)
 	);
 
-	wp_register_script( $handle, '', array(), automattic_chatrix_version(), true );
-	wp_add_inline_script( $handle, "window.ChatrixBlockConfig = $json_data;", 'before' );
-	wp_enqueue_script( $handle );
-
 	ob_start();
 	?>
 	<div <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
-		<?php // Iframe will be rendered here. ?>
+		<?php // The following element will be replaced by the <Block> component. ?>
+		<span style="display: none;" data-chatrix-block-config="<?php echo rawurlencode( $json_data ); ?>"></span>
 	</div>
 	<?php
 	return ob_get_clean();
 }
-
 
 function parse_block_json( string $block_json_path ): array {
 	// phpcs discourages file_get_contents for remote URLs, and recommends using wp_remote_get().

--- a/src/Block/block.php
+++ b/src/Block/block.php
@@ -36,9 +36,8 @@ function render( array $attributes ): string {
 
 	ob_start();
 	?>
-	<div <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?>>
-		<?php // The following element will be replaced by the <Block> component. ?>
-		<span style="display: none;" data-chatrix-block-config="<?php echo rawurlencode( $json_data ); ?>"></span>
+	<div <?php echo wp_kses_data( get_block_wrapper_attributes() ); ?> data-chatrix-block-config="<?php echo rawurlencode( $json_data ); ?>">
+		<?php // The <Block> component will be rendered here. ?>
 	</div>
 	<?php
 	return ob_get_clean();

--- a/src/Popup/popup.js
+++ b/src/Popup/popup.js
@@ -9,7 +9,7 @@
 		container.id = "chatrix-popup-container";
 		document.body.appendChild(container);
 
-		Chatrix.renderPopup(container.id, {
+		Chatrix.renderPopup(container, {
 			defaultHomeserver: config.defaultHomeserver,
 			roomId: config.roomId,
 		});


### PR DESCRIPTION
This PR makes it possible to have multiple blocks on the same page, by removing reliance on div ids, and by passing block attributes through a `data-attribute`, instead of through inline javascript.

When multiple blocks are on the same page, the behaviour is similar to having one page with a single block open in multiple tabs: opening a session in one of the blocks, closes it on all other blocks on the page.

This is the first step to address #159 