### PR TITLE
Update PHP (requires) & WP (Tested upto) versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 - Contributors: automattic, akirk, ashfame, psrpinto
 - Tags: matrix, chat
 - Requires at least: 6.0
-- Tested up to: 6.1
-- Requires PHP: 7.4
+- Tested up to: 6.1.1
+- Requires PHP: 8.0
 - License: [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html)
 - Stable tag: 0.5.1
 - GitHub Plugin URI: https://github.com/Automattic/chatrix


### PR DESCRIPTION
Since we are using `str_starts_with` and `str_contains` now, we should bump the PHP version tag to 8.0 since that's the oldest release supported now.

Also bumped WP's Tested upto tag.