### PR TITLE
add PHP8 polyfill for PHP8 functions that are in use

### DIFF
--- a/bin/create-release-artifacts.sh
+++ b/bin/create-release-artifacts.sh
@@ -31,6 +31,7 @@ PATHS_TO_INCLUDE=(
 "build"
 "src"
 "chatrix.php"
+"php8-polyfill.php"
 "LICENSE"
 "README.md"
 )

--- a/chatrix.php
+++ b/chatrix.php
@@ -15,6 +15,8 @@ if ( ! function_exists( 'Automattic\Chatrix\main' ) ) {
 	require __DIR__ . '/vendor/autoload.php';
 }
 
+require __DIR__ . '/php8-polyfill.php';
+
 function automattic_chatrix_version(): string {
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG === true ) {
 		// So that assets aren't cached in development environments.

--- a/php8-polyfill.php
+++ b/php8-polyfill.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * source: PHP docs + Laravel Framework
+ * https://www.php.net/manual/en/function.str-starts-with.php#125913
+ * https://github.com/laravel/framework/blob/8.x/src/Illuminate/Support/Str.php
+ */
+
+if ( ! function_exists( 'str_starts_with' ) ) {
+	function str_starts_with( $haystack, $needle ) {
+		return (string) $needle !== '' && strncmp( $haystack, $needle, strlen( $needle ) ) === 0;
+	}
+}
+if ( ! function_exists( 'str_ends_with' ) ) {
+	function str_ends_with( $haystack, $needle ) {
+		return $needle !== '' && substr( $haystack, -strlen( $needle ) ) === (string) $needle;
+	}
+}
+if ( ! function_exists( 'str_contains' ) ) {
+	function str_contains( $haystack, $needle ) {
+		return $needle !== '' && mb_strpos( $haystack, $needle ) !== false;
+	}
+}


### PR DESCRIPTION
I think we should issue a new release as well, since anyone attempting to run Chatrix on PHP7 would get a fatal error.