### PR TITLE
use esc_url_raw() for sanitization of url as wp_http_validate_url() rejects port in urls

### DIFF
--- a/src/Admin/Settings/settings.php
+++ b/src/Admin/Settings/settings.php
@@ -88,10 +88,21 @@ function sanitize_value( $field_name, $value, $original_value ) {
 			$value = $original_value;
 		}
 
-		if ( ! wp_http_validate_url( $value ) ) {
+		// set a default scheme if none is supplied, otherwise esc_url_raw() doesn't like it.
+		$scheme_added = false;
+		if ( is_null( wp_parse_url( $value, PHP_URL_SCHEME ) ) ) {
+			$value        = 'https://' . $value;
+			$scheme_added = true;
+		}
+
+		if ( esc_url_raw( $value ) !== $value ) {
 			// translators: %s is the value the user entered.
 			add_error( 'homeserver-invalid', sprintf( __( '<tt>%s</tt> is not a valid homeserver URL.' ), $value ) );
 			$value = $original_value;
+		}
+
+		if ( $scheme_added ) {
+			$value = substr( $value, 8 );
 		}
 	}
 

--- a/src/Admin/Settings/settings.php
+++ b/src/Admin/Settings/settings.php
@@ -95,7 +95,7 @@ function sanitize_value( $field_name, $value, $original_value ) {
 			$scheme_added = true;
 		}
 
-		if ( esc_url_raw( $value ) !== $value ) {
+		if ( sanitize_url( $value ) !== $value ) {
 			// translators: %s is the value the user entered.
 			add_error( 'homeserver-invalid', sprintf( __( '<tt>%s</tt> is not a valid homeserver URL.' ), $original_value ) );
 			$value = $original_value;

--- a/src/Admin/Settings/settings.php
+++ b/src/Admin/Settings/settings.php
@@ -97,7 +97,7 @@ function sanitize_value( $field_name, $value, $original_value ) {
 
 		if ( esc_url_raw( $value ) !== $value ) {
 			// translators: %s is the value the user entered.
-			add_error( 'homeserver-invalid', sprintf( __( '<tt>%s</tt> is not a valid homeserver URL.' ), $value ) );
+			add_error( 'homeserver-invalid', sprintf( __( '<tt>%s</tt> is not a valid homeserver URL.' ), $original_value ) );
 			$value = $original_value;
 		}
 


### PR DESCRIPTION
With this PR, values like `synapse.dev:8008` for homeserver field on settings page are accepted. Fixes #183 

I noticed, we are only attempting to sanitize the URL here and not really checking whether its actually valid & usable. Should we be doing that as well?