### PR TITLE
Release 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ Later, when Matrix makes the switch to OIDC, you are already prepared and can co
 
 ## Changelog
 
+### 0.6.0
+
+- Support for multiple blocks on the same page [[#175](https://github.com/Automattic/chatrix/pull/175)]
+- Support room alias in configuration [[#179](https://github.com/Automattic/chatrix/pull/179)]
+- Fixed a bug where port wasn't allowed in homeserver in configuration [[#184](https://github.com/Automattic/chatrix/pull/184)]
+- Provide a filter to choose to not load the logout script if required [[#165](https://github.com/Automattic/chatrix/pull/165)]
+
 ### 0.5.1
 - Fix issue that caused popup configuration to be ignored [[#173](https://github.com/Automattic/chatrix/pull/173)]
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - Tested up to: 6.1
 - Requires PHP: 7.4
 - License: [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html)
-- Stable tag: 0.5.1
+- Stable tag: 0.6.0
 - GitHub Plugin URI: https://github.com/Automattic/chatrix
 
 Matrix client for WordPress.

--- a/chatrix.php
+++ b/chatrix.php
@@ -5,7 +5,7 @@
  * Author: Automattic
  * Author URI: https://automattic.com/
  * Plugin URI: https://github.com/Automattic/chatrix
- * Version: 0.5.1
+ * Version: 0.6.0
  */
 
 use function Automattic\Chatrix\Admin\main as adminMain;
@@ -22,7 +22,7 @@ function automattic_chatrix_version(): string {
 	}
 
 	// Do not edit this line, it's automatically set by bin/prepare-release.sh.
-	$version = '0.5.1';
+	$version = '0.6.0';
 
 	return $version;
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/chatrix",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "WordPress plugin to embed a Matrix client into WordPress pages.",
   "type": "wordpress-plugin",
   "license": "GPL",

--- a/frontend/block/block.json
+++ b/frontend/block/block.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "apiVersion": 2,
   "name": "automattic/chatrix",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "title": "Chatrix",
   "category": "embed",
   "icon": "format-chat",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatrix",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Embedded Matrix client for WordPress",
   "repository": "git@github.com:Automattic/chatrix.git",
   "author": "Automattic",


### PR DESCRIPTION
[Commits since 0.5.1](https://github.com/Automattic/chatrix/compare/0.5.1...release-0.6.0)

## Changelog

- Support for multiple blocks on the same page [[#175](https://github.com/Automattic/chatrix/pull/175)]
- Support room alias in configuration [[#179](https://github.com/Automattic/chatrix/pull/179)]
- Fixed a bug where port wasn't allowed in homeserver in configuration [[#184](https://github.com/Automattic/chatrix/pull/184)]
- Provide a filter to choose to not load the logout script if required [[#165](https://github.com/Automattic/chatrix/pull/165)]