### PR TITLE
Chatrix peeking w/ guest account

### DIFF
--- a/frontend/iframe/platform/Navigation.ts
+++ b/frontend/iframe/platform/Navigation.ts
@@ -9,6 +9,7 @@ export enum Section {
     SessionLoading = "loading",
     Session = "session",
     Error = "error",
+    UnknownRoom = "unknown-room",
     Redirecting = "redirecting",
 }
 

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -165,27 +165,26 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
                 this._showLogin(loginToken);
             }
         } else {
-            if (this._singleRoomIdOrAlias) {
-                // No active session but we're in single-room mode.
-                if (!this._resolvedSingleRoomId) {
-                    try {
-                        this._resolvedSingleRoomId = await this.resolveRoomAlias(this._singleRoomIdOrAlias);
-                    } catch (error) {
-                        console.warn(error);
-                    }
-                }
-
-                if (this._resolvedSingleRoomId) {
-                    await this._showUnknownRoom(this._resolvedSingleRoomId);
-                    return;
-                }
-            }
-
             try {
                 if (!(shouldRestoreLastUrl && this.urlRouter.tryRestoreLastUrl())) {
                     const sessionInfos = await this.platform.sessionInfoStorage.getAll();
                     if (sessionInfos.length === 0) {
-                        this.navigation.push(Section.Login);
+                        if (this._singleRoomIdOrAlias) {
+                            // No active session but we're in single-room mode.
+                            if (!this._resolvedSingleRoomId) {
+                                try {
+                                    this._resolvedSingleRoomId = await this.resolveRoomAlias(this._singleRoomIdOrAlias);
+                                } catch (error) {
+                                    console.warn(error);
+                                }
+                            }
+
+                            if (this._resolvedSingleRoomId) {
+                                await this._showUnknownRoom(this._resolvedSingleRoomId);
+                            }
+                        } else {
+                            this.navigation.push(Section.Login);
+                        }
                     } else if (sessionInfos.length === 1) {
                         this.navigation.push(Section.Session, sessionInfos[0].id);
                     } else {

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -313,22 +313,19 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
         if (sessionInfos.length === 0) {
             const homeserver = await lookupHomeserver(roomId.split(':')[1], this.platform.request);
             await client.doGuestLogin(homeserver);
-            sessionInfos = await this.platform.sessionInfoStorage.getAll();
-            chosenSession = sessionInfos[0];
         } else {
-            chosenSession = sessionInfos[0];
             await client.startWithExistingSession(chosenSession.id);
         }
 
         this._setSection(() => {
             this._unknownRoomViewModel = new UnknownRoomViewModel(this.childOptions({
                 roomIdOrAlias: roomId,
-                session: chosenSession,
-                isWorldReadablePromise: this.isWorldReadableRoom(roomId, chosenSession.id),
+                session: client.session,
+                isWorldReadablePromise: this.isWorldReadableRoom(roomId, client.sessionId),
             }));
         });
 
-        this.navigation.push("session", chosenSession.id);
+        this.navigation.push("session", client.sessionId);
     }
 
     private _setSection(setter: Function) {

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -179,6 +179,7 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
                     }
                 }
             } catch (err) {
+                console.error(err);
                 this._setSection(() => this._error = err);
             }
         }

--- a/frontend/iframe/views/RootView.ts
+++ b/frontend/iframe/views/RootView.ts
@@ -4,6 +4,7 @@ import { TemplateView } from "hydrogen-web/src/platform/web/ui/general/TemplateV
 import { LoginView } from "hydrogen-web/src/platform/web/ui/login/LoginView";
 import { SessionLoadView } from "hydrogen-web/src/platform/web/ui/login/SessionLoadView";
 import { SessionPickerView } from "hydrogen-web/src/platform/web/ui/login/SessionPickerView";
+import { UnknownRoomView } from "hydrogen-web/src/platform/web/ui/session/room/UnknownRoomView";
 import { LogoutView } from "hydrogen-web/src/platform/web/ui/LogoutView";
 import { Section } from "../platform/Navigation";
 import { RootViewModel } from "../viewmodels/RootViewModel";
@@ -36,6 +37,8 @@ export class RootView extends TemplateView<RootViewModel> {
                         return new StaticView(t => t.p("Redirecting..."));
                     case Section.SessionLoading:
                         return new SessionLoadView(vm.sessionLoadViewModel);
+                    case Section.UnknownRoom:
+                        return new UnknownRoomView(vm.unknownRoomViewModel);
                     case Section.Error:
                         return new StaticView(t => {
                             return t.div({ className: "StatusView" }, [

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@wordpress/compose": "^5.17.0",
     "bs58": "^5.0.0",
-    "hydrogen-web": "Automattic/hydrogen-web#peeking_unknown_rooms",
+    "hydrogen-web": "Automattic/hydrogen-web#peeking_with_guest_login",
     "node-html-parser": "^4.0.0"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5715,9 +5715,9 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-hydrogen-web@Automattic/hydrogen-web#peeking_unknown_rooms:
+hydrogen-web@Automattic/hydrogen-web#peeking_with_guest_login:
   version "0.3.8"
-  resolved "https://codeload.github.com/Automattic/hydrogen-web/tar.gz/07cce3857a163c17ee68aa86b304bd4430de9bfd"
+  resolved "https://codeload.github.com/Automattic/hydrogen-web/tar.gz/8b71ac900e683da110077d9ae87e6902dfb73399"
   dependencies:
     "@matrix-org/olm" "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz"
     another-json "^0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3801,10 +3801,15 @@ core-js-pure@^3.25.1, core-js-pure@^3.8.1:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.25.3.tgz#66ac5bfa5754b47fdfd14f3841c5ed21c46db608"
   integrity sha512-T/7qvgv70MEvRkZ8p6BasLZmOVYKzOaWNBEHAU8FmveCJkl4nko2quqPQOmy6AJIp5MBanhz9no3A94NoRb0XA==
 
-core-js@^3.19.1, core-js@^3.6.5:
+core-js@^3.19.1:
   version "3.25.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.25.3.tgz#cbc2be50b5ddfa7981837bd8c41639f27b166593"
   integrity sha512-y1hvKXmPHvm5B7w4ln1S4uc9eV/O5+iFExSRUimnvIph11uaizFR8LFMdONN8hG3P2pipUfX4Y/fR8rAEtcHcQ==
+
+core-js@^3.6.5:
+  version "3.29.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.29.0.tgz#0273e142b67761058bcde5615c503c7406b572d6"
+  integrity sha512-VG23vuEisJNkGl6XQmFJd3rEG/so/CNatqeE+7uZAwTSwFeB/qaO0be8xZYUNWprJ/GIwL8aMt9cj1kvbpTZhg==
 
 core-util-is@~1.0.0:
   version "1.0.3"
@@ -4243,9 +4248,9 @@ domhandler@^5.0.1, domhandler@^5.0.2, domhandler@^5.0.3:
     domelementtype "^2.3.0"
 
 dompurify@^2.3.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.4.0.tgz#c9c88390f024c2823332615c9e20a453cf3825dd"
-  integrity sha512-Be9tbQMZds4a3C6xTmz68NlMfeONA//4dOavl/1rNw50E+/QO0KVpbcU0PcaW0nsQxurXls9ZocqFxk8R2mWEA==
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.4.5.tgz#0e89a27601f0bad978f9a924e7a05d5d2cccdd87"
+  integrity sha512-jggCCd+8Iqp4Tsz0nIvpcb22InKEBrGz5dw3EQJMs8HPJDsKbFIO3STYtAvCfDx26Muevn1MHVI0XxjgFfmiSA==
 
 domutils@^2.8.0:
   version "2.8.0"
@@ -5717,7 +5722,7 @@ human-signals@^2.1.0:
 
 hydrogen-web@Automattic/hydrogen-web#peeking_with_guest_login:
   version "0.3.8"
-  resolved "https://codeload.github.com/Automattic/hydrogen-web/tar.gz/8b71ac900e683da110077d9ae87e6902dfb73399"
+  resolved "https://codeload.github.com/Automattic/hydrogen-web/tar.gz/f95684bfd31bee3487a8ba75938d69e60abd6b07"
   dependencies:
     "@matrix-org/olm" "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz"
     another-json "^0.2.0"


### PR DESCRIPTION
This draft PR (not meant for merge) highlights the differences needed in Chatrix to make guest account peeking work.

This would require more changes than current's peeking PR to Hydrogen (https://github.com/Automattic/hydrogen-web/pull/7) So this branch in Chatrix uses the linked branch in Hydrogen as its dependency for Hydrogen.

To run: Pull the branch and don't forget to `yarn install` and `yarn build`

![chatrix_guest_session_peeking](https://user-images.githubusercontent.com/858906/222207939-3e23d931-e57d-48e9-82cb-7c5fc751fdd3.png)
