### PR TITLE
Don't even try to restore last url when in single room mode

### DIFF
--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -79,7 +79,7 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
     }
 
     public get singleRoomMode(): boolean {
-        return !!this._resolvedSingleRoomId;
+        return !!this._singleRoomIdOrAlias;
     }
 
     public async start() {
@@ -157,7 +157,8 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
             }
         } else {
             try {
-                if (!(shouldRestoreLastUrl && this.urlRouter.tryRestoreLastUrl())) {
+                // don't even try to restore last url when in single room mode
+                if (this.singleRoomMode || !(shouldRestoreLastUrl && this.urlRouter.tryRestoreLastUrl())) {
                     const sessionInfos = await this.platform.sessionInfoStorage.getAll();
                     if (sessionInfos.length === 0) {
                         this.navigation.push(Section.Login);


### PR DESCRIPTION
Disable functionality of "restoring last known url" when Chatrix is initialised, atleast for single room mode. This results in always going to the room upon load (when in single room mode) if you have just one session and always on session screen when you have multiple sessions.

Also switches the `singleRoomMode` getter to rely on whether the single room ID is configured as opposed to if we were able to resolve it or not. This fixes #194 