### PR TITLE
Release 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ Later, when Matrix makes the switch to OIDC, you are already prepared and can co
 
 - Implement Room Previews (Peeking) functionality [[#199](https://github.com/Automattic/chatrix/pull/199)]
 - Disable restoration to last screen when in Single room mode [[#196](https://github.com/Automattic/chatrix/pull/196)]
+- Switch to our Hydrogen's fork as dependency which includes un-merged upstream contributions
+  - Fix query params in SSO
+  - Allow create room screen to be closed on smaller width screens
+  - Ensure Service worker is started before anything else
+  - Fix bug in normalization of homeserver
+  - Room Previews (Peeking) support
+  - Fix loading of messages & timelines in some cases
 
 ### 0.6.0
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Later, when Matrix makes the switch to OIDC, you are already prepared and can co
 
 - Implement Room Previews (Peeking) functionality [[#199](https://github.com/Automattic/chatrix/pull/199)]
 - Disable restoration to last screen when in Single room mode [[#196](https://github.com/Automattic/chatrix/pull/196)]
-- Switch to our Hydrogen's fork as dependency which includes un-merged upstream contributions
+- Switch to our Hydrogen's fork (ahead of v0.3.8) as dependency which includes un-merged upstream contributions
   - Fix query params in SSO
   - Allow create room screen to be closed on smaller width screens
   - Ensure Service worker is started before anything else

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ Later, when Matrix makes the switch to OIDC, you are already prepared and can co
 
 ## Changelog
 
+### 0.7.0
+
+- Implement Room Previews (Peeking) functionality [[#199](https://github.com/Automattic/chatrix/pull/199)]
+- Disable restoration to last screen when in Single room mode [[#196](https://github.com/Automattic/chatrix/pull/196)]
+
 ### 0.6.0
 
 - Support for multiple blocks on the same page [[#175](https://github.com/Automattic/chatrix/pull/175)]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - Tested up to: 6.1
 - Requires PHP: 7.4
 - License: [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html)
-- Stable tag: 0.6.0
+- Stable tag: 0.7.0
 - GitHub Plugin URI: https://github.com/Automattic/chatrix
 
 Matrix client for WordPress.

--- a/chatrix.php
+++ b/chatrix.php
@@ -5,7 +5,7 @@
  * Author: Automattic
  * Author URI: https://automattic.com/
  * Plugin URI: https://github.com/Automattic/chatrix
- * Version: 0.6.0
+ * Version: 0.7.0
  */
 
 use function Automattic\Chatrix\Admin\main as adminMain;
@@ -22,7 +22,7 @@ function automattic_chatrix_version(): string {
 	}
 
 	// Do not edit this line, it's automatically set by bin/prepare-release.sh.
-	$version = '0.6.0';
+	$version = '0.7.0';
 
 	return $version;
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/chatrix",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "WordPress plugin to embed a Matrix client into WordPress pages.",
   "type": "wordpress-plugin",
   "license": "GPL",

--- a/frontend/block/block.json
+++ b/frontend/block/block.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "apiVersion": 2,
   "name": "automattic/chatrix",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "title": "Chatrix",
   "category": "embed",
   "icon": "format-chat",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatrix",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Embedded Matrix client for WordPress",
   "repository": "git@github.com:Automattic/chatrix.git",
   "author": "Automattic",


### PR DESCRIPTION
[Commits since 0.6.0](https://github.com/Automattic/chatrix/compare/0.6.0...release-0.7.0)

## Changelog

- Implement Room Previews (Peeking) functionality [[#199](https://github.com/Automattic/chatrix/pull/199)]
- Disable restoration to last screen when in Single room mode [[#196](https://github.com/Automattic/chatrix/pull/196)]
- Switch to our Hydrogen's fork (ahead of v0.3.8) as dependency which includes un-merged upstream contributions
  - Fix query params in SSO
  - Allow create room screen to be closed on smaller width screens
  - Ensure Service worker is started before anything else
  - Fix bug in normalization of homeserver
  - Room Previews (Peeking) support
  - Fix loading of messages & timelines in some cases