### PR TITLE
Update hydrogen dependency to tagged: chatrix-0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@wordpress/compose": "^5.17.0",
     "bs58": "^5.0.0",
-    "hydrogen-web": "Automattic/hydrogen-web#chatrix-0.7.0",
+    "hydrogen-web": "Automattic/hydrogen-web#chatrix-0.7.1",
     "node-html-parser": "^4.0.0"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5720,9 +5720,9 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-hydrogen-web@Automattic/hydrogen-web#chatrix-0.7.0:
+hydrogen-web@Automattic/hydrogen-web#chatrix-0.7.1:
   version "0.3.8"
-  resolved "https://codeload.github.com/Automattic/hydrogen-web/tar.gz/c50ff3faca14628b98457b91f3b8be133d28c761"
+  resolved "https://codeload.github.com/Automattic/hydrogen-web/tar.gz/061341d494e0f29bf22b988ff4b1d089be1e76b7"
   dependencies:
     "@matrix-org/olm" "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz"
     another-json "^0.2.0"


### PR DESCRIPTION
This PR brings this change in hydrogen:

```bash
ashfame@Ashfames-MBP hydrogen-web % git diff chatrix-0.7.0 chatrix-0.7.1
diff --git a/src/platform/web/ui/session/room/WorldReadableRoomView.js b/src/platform/web/ui/session/room/WorldReadableRoomView.js
index 0bdcb211..720eb4a1 100644
--- a/src/platform/web/ui/session/room/WorldReadableRoomView.js
+++ b/src/platform/web/ui/session/room/WorldReadableRoomView.js
@@ -40,7 +40,7 @@ export class WorldReadableRoomView extends TemplateView {
                     t.if(vm => !vm.joinAllowed, t => t.button({
                         className: "loginButton",
                         onClick: () => vm.login(),
-                    }, vm.i18n`Login`))
+                    }, vm.i18n`Log In`))
                 ])
             ])
         ]);
```

Weirdly, not reflected correctly when comparing tags on Github https://github.com/Automattic/hydrogen-web/compare/chatrix-0.7.0...Automattic:hydrogen-web:chatrix-0.7.1

After merging this PR, I will issue a new release, but mainly only to reflect updated contributors on WP.org