### PR TITLE
Don't assume plugins dir name to `chatrix`

### DIFF
--- a/src/Block/block.php
+++ b/src/Block/block.php
@@ -65,12 +65,14 @@ function register_site_status_test( string $block_json_path ) {
 		$badge  = 'red';
 	}
 
+	$relative_path = str_replace( ABSPATH, '', $block_json_path );
+
 	add_filter(
 		'site_status_tests',
-		function ( array $tests ) use ( $label, $status, $badge ) {
+		function ( array $tests ) use ( $label, $status, $badge, $relative_path ) {
 			$tests['direct']['chatrix-block-json'] = array(
 				'label' => __( 'The block.json file exists', 'chatrix' ),
-				'test'  => function () use ( $label, $status, $badge ) {
+				'test'  => function () use ( $label, $status, $badge, $relative_path ) {
 					return array(
 						'label'       => wp_kses_post( $label ),
 						'status'      => $status,
@@ -80,7 +82,7 @@ function register_site_status_test( string $block_json_path ) {
 						),
 						'description' =>
 							'<p>' .
-							__( 'If a block.json file is not found under wp-content/plugins/chatrix/build/block/block.json, the Chatrix block will not be available.', 'chatrix' ) .
+							sprintf( __( 'If a block.json file is not found under %s, the Chatrix block will not be available.', 'chatrix' ), '<code>' . $relative_path . '</code>' ) .
 							'</p>',
 						'test'        => 'chatrix-block-json',
 					);

--- a/src/Block/block.php
+++ b/src/Block/block.php
@@ -82,7 +82,12 @@ function register_site_status_test( string $block_json_path ) {
 						),
 						'description' =>
 							'<p>' .
-							sprintf( __( 'If a block.json file is not found under %s, the Chatrix block will not be available.', 'chatrix' ), '<code>' . $relative_path . '</code>' ) .
+							sprintf(
+								/* translators: %1$s is the file name, %2$s is the file path */
+								__( 'If a %1$s file is not found under %2$s, the Chatrix block will not be available.', 'chatrix' ),
+								'<code>block.json</code>',
+								'<code>' . $relative_path . '</code>'
+							) .
 							'</p>',
 						'test'        => 'chatrix-block-json',
 					);

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -64,5 +64,5 @@ function register_scripts() {
 }
 
 function root_url(): string {
-	return plugins_url() . '/chatrix/build';
+	return plugins_url( 'build/', dirname(__FILE__ ) );
 }

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -64,5 +64,5 @@ function register_scripts() {
 }
 
 function root_url(): string {
-	return plugins_url( 'build/', dirname(__FILE__ ) );
+	return plugins_url( 'build', __DIR__ );
 }


### PR DESCRIPTION
Make it work for when Chatrix is installed under a custom folder like `wp-content/my-plugins`
- Improve root_url() to work under any folder

Also fix the relative path shown in `site_status_tests`