### PR TITLE
Allow navigating away from unknown room view

### DIFF
--- a/frontend/iframe/viewmodels/SessionViewModel.ts
+++ b/frontend/iframe/viewmodels/SessionViewModel.ts
@@ -1,5 +1,6 @@
 import { SessionViewModel as BaseSessionViewModel } from "hydrogen-web/src/domain/session/SessionViewModel";
 import { RoomViewModel } from "./RoomViewModel";
+import { UnknownRoomViewModel } from "./UnknownRoomVideoModel";
 import { SettingsViewModel } from "./SettingsViewModel";
 
 export class SessionViewModel extends BaseSessionViewModel {
@@ -109,5 +110,15 @@ export class SessionViewModel extends BaseSessionViewModel {
             return roomVM;
         }
         return null;
+    }
+
+    async _createUnknownRoomViewModel(roomIdOrAlias, isWorldReadablePromise) {
+        return new UnknownRoomViewModel(super.childOptions({
+            roomIdOrAlias,
+            session: this.client.session,
+            isWorldReadablePromise: isWorldReadablePromise,
+            guestJoinAllowed: false,
+            singleRoomId: this._singleRoomId,
+        }));
     }
 }

--- a/frontend/iframe/viewmodels/UnknownRoomVideoModel.ts
+++ b/frontend/iframe/viewmodels/UnknownRoomVideoModel.ts
@@ -1,0 +1,29 @@
+import {UnknownRoomViewModel as BaseUnknownRoomViewModel} from "hydrogen-web/src/domain/session/room/UnknownRoomViewModel";
+import {SegmentType} from "hydrogen-web/src/domain/navigation";
+import {Segment} from "hydrogen-web/src/domain/navigation/Navigation";
+
+export class UnknownRoomViewModel extends BaseUnknownRoomViewModel {
+    private readonly _singleRoomId: any;
+
+    constructor(options) {
+        super(options);
+        this._singleRoomId = options.singleRoomId;
+    }
+
+    get navigation() {
+        return super.navigation;
+    }
+
+    get urlRouter() {
+        return super.urlRouter;
+    }
+
+    get closeUrl() {
+        if (this._singleRoomId) {
+            const path = this.navigation.path.with(new Segment<SegmentType>("session"));
+            return this.urlRouter.urlForPath(path);
+        }
+
+        return super.closeUrl;
+    }
+}


### PR DESCRIPTION
In this PR:

- We bring some change from our fork by updating dependency to the latest master tag. I supposed we would keep them incrementing as needed and tag it when we are ready to release a new version of Chatrix.
- Fix a path which needed to be changed post merge of sync-worker work in our hydrogen fork.
- Override `UnknownRoomViewModel` class to define a different `closeUrl()` for single room mode

| Header with back arrow link shown now | Screen shown after you click the back arrow |
|--------|--------|
| ![Screenshot 2023-03-31 at 12 18 14 AM](https://user-images.githubusercontent.com/858906/228954862-ed2645d6-7170-4ff0-9890-9184e5ff1b36.png) | ![Screenshot 2023-03-31 at 12 18 25 AM](https://user-images.githubusercontent.com/858906/228954849-1ed884da-db3c-46ab-9bdb-73da99e2df69.png) | 



