### PR TITLE
Always register the admin filters

### DIFF
--- a/src/Admin/admin.php
+++ b/src/Admin/admin.php
@@ -8,17 +8,6 @@ function main() {
 }
 
 function init_settings() {
-	if ( empty( $_SERVER['REQUEST_URI'] ) ) {
-		return;
-	}
-
-	$uri             = basename( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
-	$is_options_page = str_starts_with( $uri, 'options-general.php?page=chatrix' ) || 'options.php' === $uri;
-
-	if ( ! $is_options_page ) {
-		return;
-	}
-
 	add_action( 'admin_enqueue_scripts', 'Automattic\Chatrix\Admin\Settings\enqueue' );
 	add_action( 'admin_init', 'Automattic\Chatrix\Admin\Settings\init' );
 }


### PR DESCRIPTION
On installs where the `wp-admin` is not in `/`, the settings screen is empty (see https://wpgp.kirk.at/?lang=de&plugin=chatrix). This is because we do some premature optimization to not register the filters. 

![Screenshot 2023-04-14 at 10 03 52](https://user-images.githubusercontent.com/203408/232007816-a44c4715-643b-433d-a5a3-dba9f82da9d4.png)

By removing that optimization, the settings load also in the above case.