### PR TITLE
Release 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ Later, when Matrix makes the switch to OIDC, you are already prepared and can co
 
 ## Changelog
 
+### 0.8.0
+
+- Fix issue when chatrix plugin is not installed in the default location [[#205](https://github.com/Automattic/chatrix/pull/205)]
+- Fix issue with z-index of the popup [[#207](https://github.com/Automattic/chatrix/pull/207)]
+- Fix issue that prevented navigating away from the *unknown room* screen [[#213](https://github.com/Automattic/chatrix/pull/213)]
+- Allow multiple blocks on the same page or on different browser tabs (behind feature flag, still unstable) [[#214](https://github.com/Automattic/chatrix/pull/214)]
+
 ### 0.7.1
 
 - Fix button text from 'Login' to 'Log In'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - Tested up to: 6.2
 - Requires PHP: 7.4
 - License: [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html)
-- Stable tag: 0.7.1
+- Stable tag: 0.8.0
 - GitHub Plugin URI: https://github.com/Automattic/chatrix
 
 Matrix client for WordPress.

--- a/chatrix.php
+++ b/chatrix.php
@@ -5,7 +5,7 @@
  * Author: WordPress.Org Community
  * Author URI: https://wordpress.org/
  * Plugin URI: https://github.com/Automattic/chatrix
- * Version: 0.7.1
+ * Version: 0.8.0
  */
 
 use function Automattic\Chatrix\Admin\main as adminMain;
@@ -22,7 +22,7 @@ function automattic_chatrix_version(): string {
 	}
 
 	// Do not edit this line, it's automatically set by bin/prepare-release.sh.
-	$version = '0.7.1';
+	$version = '0.8.0';
 
 	return $version;
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/chatrix",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "WordPress plugin to embed a Matrix client into WordPress pages.",
   "type": "wordpress-plugin",
   "license": "GPL",

--- a/frontend/block/block.json
+++ b/frontend/block/block.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "apiVersion": 2,
   "name": "automattic/chatrix",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "title": "Chatrix",
   "category": "embed",
   "icon": "format-chat",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatrix",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Embedded Matrix client for WordPress",
   "repository": "git@github.com:Automattic/chatrix.git",
   "author": "Automattic",


### PR DESCRIPTION
[Commits since 0.7.1](https://github.com/Automattic/chatrix/compare/0.7.1...release-0.8.0)

## Changelog

- Fix issue when chatrix plugin is not installed in the default location [[#205](https://github.com/Automattic/chatrix/pull/205)]
- Fix issue with z-index of the popup [[#207](https://github.com/Automattic/chatrix/pull/207)]
- Fix issue that prevented navigating away from the *unknown room* screen [[#213](https://github.com/Automattic/chatrix/pull/213)]
- Allow multiple blocks on the same page or on different browser tabs (behind feature flag, still unstable) [[#214](https://github.com/Automattic/chatrix/pull/214)]