### PR TITLE
Correctly remember last url when multiple blocks are on the same page

### DIFF
--- a/frontend/block/block.json
+++ b/frontend/block/block.json
@@ -8,6 +8,10 @@
   "icon": "format-chat",
   "description": "Matrix client",
   "attributes": {
+    "uuid": {
+      "type": "string",
+      "default": ""
+    },
     "defaultHomeserver": {
       "type": "string",
       "default": ""

--- a/frontend/block/block.json
+++ b/frontend/block/block.json
@@ -8,7 +8,7 @@
   "icon": "format-chat",
   "description": "Matrix client",
   "attributes": {
-    "uuid": {
+    "instanceId": {
       "type": "string",
       "default": ""
     },

--- a/frontend/block/edit.tsx
+++ b/frontend/block/edit.tsx
@@ -17,7 +17,7 @@ export default function Edit(props: Props): WPElement {
 
     const blockProps: BlockProps = {
         focusable: true,
-        attributes,
+        attributes: parsedAttributes,
         iframeUrl: getIframeUrl(),
     };
 

--- a/frontend/block/edit.tsx
+++ b/frontend/block/edit.tsx
@@ -11,17 +11,24 @@ interface Props {
     setAttributes: Function,
 }
 
+let uuids: string[] = [];
+
 export default function Edit(props: Props): WPElement {
     const { attributes, setAttributes } = props;
 
-    // Set uuid if it's not set.
+    // Set uuid if it's not set, or if it already exists on the page (which happens when the block is duplicated).
     useEffect(() => {
         // @ts-ignore
-        const { uuid } = attributes;
-        if (!uuid || uuid === "") {
-            const id = (Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)).toString();
-            setAttributes({uuid: id});
+        let { uuid } = attributes;
+        const hasUuid = uuid && uuid !== "";
+        const isUuidDuplicated = hasUuid && uuids.includes(uuid);
+
+        if (!hasUuid || isUuidDuplicated) {
+            uuid = (Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)).toString();
+            setAttributes({ uuid });
         }
+
+        uuids.push(uuid);
     }, []);
 
     const parsedAttributes = parseAttributes(attributes);

--- a/frontend/block/edit.tsx
+++ b/frontend/block/edit.tsx
@@ -1,6 +1,6 @@
 import { useBlockProps } from "@wordpress/block-editor";
 import { ResizableBox } from "@wordpress/components";
-import { WPElement } from '@wordpress/element';
+import { useEffect, WPElement } from '@wordpress/element';
 import { getIframeUrl } from "../app";
 import { Block, BlockProps, parseAttributes } from "../components/block";
 import './editor.scss';
@@ -13,8 +13,18 @@ interface Props {
 
 export default function Edit(props: Props): WPElement {
     const { attributes, setAttributes } = props;
-    const parsedAttributes = parseAttributes(attributes);
 
+    // Set uuid if it's not set.
+    useEffect(() => {
+        // @ts-ignore
+        const { uuid } = attributes;
+        if (!uuid || uuid === "") {
+            const id = (Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)).toString();
+            setAttributes({uuid: id});
+        }
+    }, []);
+
+    const parsedAttributes = parseAttributes(attributes);
     const blockProps: BlockProps = {
         focusable: true,
         attributes: parsedAttributes,

--- a/frontend/block/edit.tsx
+++ b/frontend/block/edit.tsx
@@ -11,24 +11,24 @@ interface Props {
     setAttributes: Function,
 }
 
-let uuids: string[] = [];
+let instanceIds: string[] = [];
 
 export default function Edit(props: Props): WPElement {
     const { attributes, setAttributes } = props;
 
-    // Set uuid if it's not set, or if it already exists on the page (which happens when the block is duplicated).
+    // Set instanceId if it's not set, or if it already exists on the page (which happens when the block is duplicated).
     useEffect(() => {
         // @ts-ignore
-        let { uuid } = attributes;
-        const hasUuid = uuid && uuid !== "";
-        const isUuidDuplicated = hasUuid && uuids.includes(uuid);
+        let { instanceId } = attributes;
+        const hasInstanceId = instanceId && instanceId !== "";
+        const isInstanceIdDuplicated = hasInstanceId && instanceIds.includes(instanceId);
 
-        if (!hasUuid || isUuidDuplicated) {
-            uuid = (Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)).toString();
-            setAttributes({ uuid });
+        if (!hasInstanceId || isInstanceIdDuplicated) {
+            instanceId = (Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)).toString();
+            setAttributes({ instanceId });
         }
 
-        uuids.push(uuid);
+        instanceIds.push(instanceId);
     }, []);
 
     const parsedAttributes = parseAttributes(attributes);

--- a/frontend/block/view.ts
+++ b/frontend/block/view.ts
@@ -19,9 +19,9 @@ async function renderAllBlocks() {
             attributes: attributes,
         };
 
-        if (!attributes.uuid) {
-            // In earlier versions of the block, there was no uuid attribute, so it can be undefined.
-            console.warn('Chatrix block is missing the uuid attribute. Re-save the page to fix this.');
+        if (!attributes.instanceId) {
+            // In earlier versions of the block, there was no instanceId attribute, so it can be undefined.
+            console.warn('Chatrix block is missing the instanceId attribute. Re-save the page to fix this.');
         }
 
         renderBlock(container, props);

--- a/frontend/block/view.ts
+++ b/frontend/block/view.ts
@@ -1,4 +1,5 @@
 import { BlockProps, renderBlock } from "../app";
+import { parseAttributes } from "../components/block";
 
 window.addEventListener('DOMContentLoaded', () => {
     renderAllBlocks().catch(error => {
@@ -14,7 +15,7 @@ async function renderAllBlocks() {
     for (const container of containers) {
         const config = getConfigFromDataAttribute(container);
         const props: BlockProps = {
-            attributes: config.attributes,
+            attributes: parseAttributes(config.attributes),
         };
 
         renderBlock(container, props);

--- a/frontend/block/view.ts
+++ b/frontend/block/view.ts
@@ -14,9 +14,15 @@ async function renderAllBlocks() {
     const containers = <HTMLCollectionOf<HTMLElement>>document.getElementsByClassName('wp-block-automattic-chatrix');
     for (const container of containers) {
         const config = getConfigFromDataAttribute(container);
+        const attributes = parseAttributes(config.attributes);
         const props: BlockProps = {
-            attributes: parseAttributes(config.attributes),
+            attributes: attributes,
         };
+
+        if (!attributes.uuid) {
+            // In earlier versions of the block, there was no uuid attribute, so it can be undefined.
+            console.warn('Chatrix block is missing the uuid attribute. Re-save the page to fix this.');
+        }
 
         renderBlock(container, props);
     }

--- a/frontend/components/block/attributes.ts
+++ b/frontend/components/block/attributes.ts
@@ -1,7 +1,7 @@
 import { Unit, ValueWithUnit } from "./unit";
 
 export interface BlockAttributes {
-    uuid: string,
+    instanceId: string,
     defaultHomeserver?: string,
     roomId?: string,
     height?: Height,
@@ -13,7 +13,7 @@ export interface BlockAttributes {
 
 export function parseAttributes(attributes): BlockAttributes {
     const {
-        uuid,
+        instanceId,
         defaultHomeserver,
         roomId,
         height,
@@ -24,7 +24,7 @@ export function parseAttributes(attributes): BlockAttributes {
     } = attributes;
 
     return {
-        uuid,
+        instanceId,
         defaultHomeserver: defaultHomeserver ?? '',
         roomId: roomId ?? '',
         height: height ? new Height(height.value, height.unit) : undefined,

--- a/frontend/components/block/attributes.ts
+++ b/frontend/components/block/attributes.ts
@@ -23,11 +23,6 @@ export function parseAttributes(attributes): BlockAttributes {
         borderColor,
     } = attributes;
 
-    if (!uuid) {
-        // In earlier versions of the block, uuid was not an attribute, so it can be undefined.
-        console.warn('Chatrix block is missing the uuid attribute. Re-save the page to fix this.');
-    }
-
     return {
         uuid,
         defaultHomeserver: defaultHomeserver ?? '',

--- a/frontend/components/block/attributes.ts
+++ b/frontend/components/block/attributes.ts
@@ -1,6 +1,7 @@
 import { Unit, ValueWithUnit } from "./unit";
 
 export interface BlockAttributes {
+    uuid: string,
     defaultHomeserver?: string,
     roomId?: string,
     height?: Height,
@@ -12,6 +13,7 @@ export interface BlockAttributes {
 
 export function parseAttributes(attributes): BlockAttributes {
     const {
+        uuid,
         defaultHomeserver,
         roomId,
         height,
@@ -21,7 +23,13 @@ export function parseAttributes(attributes): BlockAttributes {
         borderColor,
     } = attributes;
 
+    if (!uuid) {
+        // In earlier versions of the block, uuid was not an attribute, so it can be undefined.
+        console.warn('Chatrix block is missing the uuid attribute. Re-save the page to fix this.');
+    }
+
     return {
+        uuid,
         defaultHomeserver: defaultHomeserver ?? '',
         roomId: roomId ?? '',
         height: height ? new Height(height.value, height.unit) : undefined,

--- a/frontend/components/block/attributes.ts
+++ b/frontend/components/block/attributes.ts
@@ -11,14 +11,24 @@ export interface BlockAttributes {
 }
 
 export function parseAttributes(attributes): BlockAttributes {
+    const {
+        defaultHomeserver,
+        roomId,
+        height,
+        borderWidth,
+        borderRadius,
+        borderStyle,
+        borderColor,
+    } = attributes;
+
     return {
-        defaultHomeserver: attributes.defaultHomeserver ?? '',
-        roomId: attributes.roomId ?? '',
-        height: attributes.height ? new Height(attributes.height.value, attributes.height.unit) : undefined,
-        borderWidth: attributes.borderWidth ? new BorderWidth(attributes.borderWidth.value, attributes.borderWidth.unit) : undefined,
-        borderRadius: attributes.borderRadius ? new BorderRadius(attributes.borderRadius.value, attributes.borderRadius.unit) : undefined,
-        borderStyle: attributes.borderStyle,
-        borderColor: attributes.borderColor,
+        defaultHomeserver: defaultHomeserver ?? '',
+        roomId: roomId ?? '',
+        height: height ? new Height(height.value, height.unit) : undefined,
+        borderWidth: borderWidth ? new BorderWidth(borderWidth.value, borderWidth.unit) : undefined,
+        borderRadius: borderRadius ? new BorderRadius(borderRadius.value, borderRadius.unit) : undefined,
+        borderStyle,
+        borderColor,
     };
 }
 

--- a/frontend/components/block/attributes.ts
+++ b/frontend/components/block/attributes.ts
@@ -1,6 +1,6 @@
 import { Unit, ValueWithUnit } from "./unit";
 
-interface Attributes {
+export interface BlockAttributes {
     defaultHomeserver?: string,
     roomId?: string,
     height?: Height,
@@ -10,7 +10,7 @@ interface Attributes {
     borderColor?: string,
 }
 
-export function parseAttributes(attributes): Attributes {
+export function parseAttributes(attributes): BlockAttributes {
     return {
         defaultHomeserver: attributes.defaultHomeserver ?? '',
         roomId: attributes.roomId ?? '',

--- a/frontend/components/block/block.tsx
+++ b/frontend/components/block/block.tsx
@@ -1,14 +1,14 @@
 import { Chat, ChatProps } from "../chat";
-import { parseAttributes } from "./attributes";
+import { BlockAttributes } from "./attributes";
 
 export interface BlockProps {
     focusable?: boolean,
-    attributes: object,
+    attributes: BlockAttributes,
     iframeUrl: URL,
 }
 
 export function Block(props: BlockProps) {
-    const attributes = parseAttributes(props.attributes);
+    const { attributes } = props;
 
     const style = {
         height: attributes.height ? attributes.height.toString() : '',

--- a/frontend/components/block/block.tsx
+++ b/frontend/components/block/block.tsx
@@ -10,7 +10,7 @@ export interface BlockProps {
 export function Block(props: BlockProps) {
     const { focusable, iframeUrl } = props;
     const {
-        uuid,
+        instanceId,
         defaultHomeserver,
         roomId,
         height,
@@ -31,7 +31,7 @@ export function Block(props: BlockProps) {
     const chatProps: ChatProps = {
         focusable,
         iframeUrl,
-        uuid,
+        instanceId,
         defaultHomeserver,
         roomId,
     };

--- a/frontend/components/block/block.tsx
+++ b/frontend/components/block/block.tsx
@@ -10,6 +10,7 @@ export interface BlockProps {
 export function Block(props: BlockProps) {
     const { focusable, iframeUrl } = props;
     const {
+        uuid,
         defaultHomeserver,
         roomId,
         height,
@@ -30,6 +31,7 @@ export function Block(props: BlockProps) {
     const chatProps: ChatProps = {
         focusable,
         iframeUrl,
+        uuid,
         defaultHomeserver,
         roomId,
     };

--- a/frontend/components/block/block.tsx
+++ b/frontend/components/block/block.tsx
@@ -8,21 +8,30 @@ export interface BlockProps {
 }
 
 export function Block(props: BlockProps) {
-    const { attributes } = props;
+    const { focusable, iframeUrl } = props;
+    const {
+        defaultHomeserver,
+        roomId,
+        height,
+        borderWidth,
+        borderRadius,
+        borderStyle,
+        borderColor,
+    } = props.attributes;
 
     const style = {
-        height: attributes.height ? attributes.height.toString() : '',
-        borderWidth: attributes.borderWidth ? attributes.borderWidth.toString() : 0,
-        borderRadius: attributes.borderRadius ? attributes.borderRadius.toString() : "",
-        borderStyle: attributes.borderStyle ?? '',
-        borderColor: attributes.borderColor ?? '',
+        height: height ? height.toString() : '',
+        borderWidth: borderWidth ? borderWidth.toString() : 0,
+        borderRadius: borderRadius ? borderRadius.toString() : "",
+        borderStyle: borderStyle ?? '',
+        borderColor: borderColor ?? '',
     };
 
     const chatProps: ChatProps = {
-        focusable: props.focusable,
-        iframeUrl: props.iframeUrl,
-        defaultHomeserver: attributes.defaultHomeserver,
-        roomId: attributes.roomId,
+        focusable,
+        iframeUrl,
+        defaultHomeserver,
+        roomId,
     };
 
     return (

--- a/frontend/components/chat/chat.tsx
+++ b/frontend/components/chat/chat.tsx
@@ -4,7 +4,7 @@ import { IframeUrl } from "./url";
 export interface ChatProps {
     focusable?: boolean,
     iframeUrl: URL,
-    uuid: string,
+    instanceId: string,
     defaultHomeserver?: string,
     roomId?: string,
 }
@@ -13,14 +13,14 @@ export function Chat(props: ChatProps) {
     const {
         focusable,
         iframeUrl,
-        uuid,
+        instanceId,
         defaultHomeserver,
         roomId
     } = props;
 
     const ref = focusable ? useFocusableIframe() : undefined;
     const url = new IframeUrl(iframeUrl, {
-        uuid,
+        instanceId,
         defaultHomeserver,
         roomId,
     });

--- a/frontend/components/chat/chat.tsx
+++ b/frontend/components/chat/chat.tsx
@@ -9,11 +9,17 @@ export interface ChatProps {
 }
 
 export function Chat(props: ChatProps) {
-    const ref = props.focusable ? useFocusableIframe() : undefined;
+    const {
+        focusable,
+        iframeUrl,
+        defaultHomeserver,
+        roomId
+    } = props;
 
-    const iframeUrl = new IframeUrl(props.iframeUrl, {
-        defaultHomeserver: props.defaultHomeserver,
-        roomId: props.roomId,
+    const ref = focusable ? useFocusableIframe() : undefined;
+    const url = new IframeUrl(iframeUrl, {
+        defaultHomeserver,
+        roomId,
     });
 
     return (
@@ -21,7 +27,7 @@ export function Chat(props: ChatProps) {
             <iframe
                 // @ts-ignore
                 ref={ref}
-                src={iframeUrl.toString()}
+                src={url.toString()}
             ></iframe>
         </div>
     );

--- a/frontend/components/chat/chat.tsx
+++ b/frontend/components/chat/chat.tsx
@@ -4,6 +4,7 @@ import { IframeUrl } from "./url";
 export interface ChatProps {
     focusable?: boolean,
     iframeUrl: URL,
+    uuid: string,
     defaultHomeserver?: string,
     roomId?: string,
 }
@@ -12,12 +13,14 @@ export function Chat(props: ChatProps) {
     const {
         focusable,
         iframeUrl,
+        uuid,
         defaultHomeserver,
         roomId
     } = props;
 
     const ref = focusable ? useFocusableIframe() : undefined;
     const url = new IframeUrl(iframeUrl, {
+        uuid,
         defaultHomeserver,
         roomId,
     });

--- a/frontend/components/chat/url.ts
+++ b/frontend/components/chat/url.ts
@@ -1,7 +1,7 @@
 const LOGIN_TOKEN_PARAM_NAME = "loginToken";
 
 type IframeParams = {
-    uuid: string,
+    instanceId: string,
     defaultHomeserver?: string
     roomId?: string,
 }

--- a/frontend/components/chat/url.ts
+++ b/frontend/components/chat/url.ts
@@ -1,6 +1,7 @@
 const LOGIN_TOKEN_PARAM_NAME = "loginToken";
 
 type IframeParams = {
+    uuid: string,
     defaultHomeserver?: string
     roomId?: string,
 }

--- a/frontend/iframe/config/ConfigFactory.ts
+++ b/frontend/iframe/config/ConfigFactory.ts
@@ -12,7 +12,7 @@ export class ConfigFactory {
         };
 
         return {
-            uuid: getQueryParam("uuid") ?? "",
+            instanceId: getQueryParam("instanceId") ?? "",
             defaultHomeserver: getQueryParam("defaultHomeserver") ?? "",
             roomId: getQueryParam("roomId") ?? "",
             themeManifests: [

--- a/frontend/iframe/config/ConfigFactory.ts
+++ b/frontend/iframe/config/ConfigFactory.ts
@@ -12,6 +12,7 @@ export class ConfigFactory {
         };
 
         return {
+            uuid: getQueryParam("uuid") ?? "",
             defaultHomeserver: getQueryParam("defaultHomeserver") ?? "",
             roomId: getQueryParam("roomId") ?? "",
             themeManifests: [

--- a/frontend/iframe/config/IConfig.ts
+++ b/frontend/iframe/config/IConfig.ts
@@ -3,7 +3,7 @@ export interface IConfig {
      * Unique identifier for this instance of the client.
      * When multiple clients are embedded on the same page, this is used to distinguish them.
      */
-    uuid: string;
+    instanceId: string;
 
     /**
      * The default homeserver used by Hydrogen; autofilled in the login UI.

--- a/frontend/iframe/config/IConfig.ts
+++ b/frontend/iframe/config/IConfig.ts
@@ -1,5 +1,11 @@
 export interface IConfig {
     /**
+     * Unique identifier for this instance of the client.
+     * When multiple clients are embedded on the same page, this is used to distinguish them.
+     */
+    uuid: string;
+
+    /**
      * The default homeserver used by Hydrogen; autofilled in the login UI.
      * eg: https://matrix.org
      */

--- a/frontend/iframe/platform/History.ts
+++ b/frontend/iframe/platform/History.ts
@@ -1,12 +1,12 @@
 import { History as BaseHistory } from "hydrogen-web/src/platform/web/dom/History";
 
 export class History extends BaseHistory {
-    private _uuid: string;
+    private readonly _instanceId: string;
     private _lastSessionHash: string | null | undefined;
 
-    constructor(uuid: string) {
+    constructor(instanceId: string) {
         super();
-        this._uuid = uuid;
+        this._instanceId = instanceId;
     }
 
     get() {
@@ -37,6 +37,6 @@ export class History extends BaseHistory {
     }
 
     private get urlHashKey(): string {
-        return `chatrix_last_url_hash_${this._uuid}`;
+        return `chatrix_last_url_hash_${this._instanceId}`;
     }
 }

--- a/frontend/iframe/platform/History.ts
+++ b/frontend/iframe/platform/History.ts
@@ -37,6 +37,6 @@ export class History extends BaseHistory {
     }
 
     private get urlHashKey(): string {
-        return `chatrix_last_url_hash_${this._instanceId}`;
+        return `chatrix_${this._instanceId}_last_url_hash`;
     }
 }

--- a/frontend/iframe/platform/History.ts
+++ b/frontend/iframe/platform/History.ts
@@ -1,10 +1,12 @@
 import { History as BaseHistory } from "hydrogen-web/src/platform/web/dom/History";
 
 export class History extends BaseHistory {
+    private _uuid: string;
     private _lastSessionHash: string | null | undefined;
 
-    constructor() {
+    constructor(uuid: string) {
         super();
+        this._uuid = uuid;
     }
 
     get() {
@@ -21,16 +23,20 @@ export class History extends BaseHistory {
     }
 
     onSubscribeFirst() {
-        this._lastSessionHash = window.localStorage?.getItem("chatrix_last_url_hash");
+        this._lastSessionHash = window.localStorage?.getItem(this.urlHashKey);
         // @ts-ignore
         window.addEventListener('hashchange', this);
     }
 
     _storeHash(hash) {
-        window.localStorage?.setItem("chatrix_last_url_hash", hash);
+        window.localStorage?.setItem(this.urlHashKey, hash);
     }
 
     replaceUrlSilently(url) {
         super.replaceUrlSilently(url);
+    }
+
+    private get urlHashKey(): string {
+        return `chatrix_last_url_hash_${this._uuid}`;
     }
 }

--- a/frontend/iframe/platform/Platform.ts
+++ b/frontend/iframe/platform/Platform.ts
@@ -25,7 +25,7 @@ export class Platform extends BasePlatform {
         super._serviceWorkerHandler = serviceWorkerHandler;
         super.settingsStorage = new SettingsStorage("chatrix_setting_v1_");
         super.sessionInfoStorage = new SessionInfoStorage("chatrix_sessions_v1");
-        super.history = new History(this.config.uuid);
+        super.history = new History(this.config.instanceId);
     }
 
     public get history(): History {

--- a/frontend/iframe/platform/Platform.ts
+++ b/frontend/iframe/platform/Platform.ts
@@ -25,7 +25,7 @@ export class Platform extends BasePlatform {
         super._serviceWorkerHandler = serviceWorkerHandler;
         super.settingsStorage = new SettingsStorage("chatrix_setting_v1_");
         super.sessionInfoStorage = new SessionInfoStorage("chatrix_sessions_v1");
-        super.history = new History();
+        super.history = new History(this.config.uuid);
     }
 
     public get history(): History {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -36,6 +36,7 @@
 
         renderBlock(document.getElementById("root-block"), {
             attributes: {
+                uuid: "block",
                 defaultHomeserver: env.VITE_HOMESERVER,
                 roomId: env.VITE_ROOM_ID,
             }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -36,7 +36,7 @@
 
         renderBlock(document.getElementById("root-block"), {
             attributes: {
-                uuid: "block",
+                instanceId: "block",
                 defaultHomeserver: env.VITE_HOMESERVER,
                 roomId: env.VITE_ROOM_ID,
             }

--- a/src/Popup/popup.js
+++ b/src/Popup/popup.js
@@ -11,6 +11,7 @@
 		container.style.zIndex = 1;
 
 		Chatrix.renderPopup(container, {
+			instanceId: config.instanceId,
 			defaultHomeserver: config.defaultHomeserver,
 			roomId: config.roomId,
 		});

--- a/src/Popup/popup.php
+++ b/src/Popup/popup.php
@@ -5,10 +5,6 @@ namespace Automattic\Chatrix\Popup;
 use function Automattic\Chatrix\Admin\Settings\get as get_chatrix_settings;
 use const Automattic\Chatrix\SCRIPT_HANDLE_APP;
 
-function chatrix_config() {
-	return apply_filters( 'chatrix_config', array() );
-}
-
 function register() {
 	register_default_instance();
 	define_config();
@@ -117,7 +113,7 @@ function init_javascript() {
 	add_action(
 		'wp_enqueue_scripts',
 		function () {
-			$config = chatrix_config();
+			$config = apply_filters( 'chatrix_config', array() );
 			if ( empty( $config ) ) {
 				return;
 			}

--- a/src/Popup/popup.php
+++ b/src/Popup/popup.php
@@ -62,7 +62,8 @@ function define_config() {
 			$instances = apply_filters( 'chatrix_instances', array() );
 
 			foreach ( $instances as $instance_id => $instance ) {
-				$instance_config = array(
+				$instance['instance_id'] = $instance_id;
+				$instance_config         = array(
 					'url'         => rest_url( "chatrix/config/$instance_id" ),
 					'config'      => $instance,
 					'instance_id' => $instance_id,
@@ -121,6 +122,7 @@ function init_javascript() {
 			$handle    = 'chatrix-popup';
 			$json_data = wp_json_encode(
 				array(
+					'instanceId'        => 'popup_' . $config['instance_id'],
 					'defaultHomeserver' => $config['config']['homeserver'],
 					'roomId'            => empty( $config['config']['room_id'] ) ? null : $config['config']['room_id'],
 				)

--- a/src/Popup/popup.php
+++ b/src/Popup/popup.php
@@ -35,10 +35,9 @@ function register_default_instance() {
 
 			return array(
 				'default' => array(
-					'homeserver'    => $settings['homeserver'],
-					'room_id'       => $settings['room'],
-					'login_methods' => array( 'password', 'sso' ), // TODO: don't hardcode login methods.
-					'pages'         => 'all' === $settings['show_on'] ? 'all' : $settings['pages'],
+					'homeserver' => $settings['homeserver'],
+					'room_id'    => $settings['room'],
+					'pages'      => 'all' === $settings['show_on'] ? 'all' : $settings['pages'],
 				),
 			);
 		}


### PR DESCRIPTION
When multiple blocks are on the same page, in different screens (e.g. different rooms), refreshing the page would not correctly bring each block to the screen where they were previously on.

This PR fixes that by introducing an `instanceId` attribute which is unique for each block on a page. We then use that `instanceId` to namespace the `chatrix_last_url_hash` property in local storage, so that it becomes `chatrix_abc123_last_url_hash` (where `abc123` is the `instanceId`).

**Note:** For blocks created before this PR, the pages will need to be re-saved for the block(s) to get an `instanceId`.

## Screen recording


https://user-images.githubusercontent.com/550401/232537034-b2cd16ab-c72c-4d51-898b-91b70cbdb743.mov

