### PR TITLE
Fix issues with single-room mode and guest login

### DIFF
--- a/frontend/iframe/platform/History.ts
+++ b/frontend/iframe/platform/History.ts
@@ -36,6 +36,10 @@ export class History extends BaseHistory {
         super.replaceUrlSilently(url);
     }
 
+    getLastSessionUrl() {
+        return super.getLastSessionUrl();
+    }
+
     private get urlHashKey(): string {
         return `chatrix_${this._instanceId}_last_url_hash`;
     }

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -185,11 +185,12 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
 
         // Send to login or, when in single-room mode, try registering guest user.
         if (sessionInfos.length === 0) {
-            if (this._resolvedSingleRoomId) {
-                await this._showUnknownRoom(this._resolvedSingleRoomId);
-            } else {
+            if (!this._resolvedSingleRoomId) {
                 this.navigation.push(Section.Login);
+                return;
             }
+
+            await this._showUnknownRoom(this._resolvedSingleRoomId);
             return;
         }
 

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -212,29 +212,16 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
         this.navigation.push(Section.Session);
     }
 
-    private async resolveRoomAlias(roomIdOrAlias: string, sessionId?: string): Promise<string> {
+    private async resolveRoomAlias(roomIdOrAlias: string): Promise<string> {
         if (roomIdOrAlias.startsWith('!')) {
             return roomIdOrAlias;
         }
 
-        let sessionInfo;
-        if (sessionId) {
-            sessionInfo = await this.platform.sessionInfoStorage.get(sessionId);
-        }
-        let homeserver: string;
-        let accessToken: string;
-        if (sessionInfo) {
-            homeserver = sessionInfo.homeserver;
-            accessToken = sessionInfo.accessToken;
-        } else {
-            homeserver = await lookupHomeserver(roomIdOrAlias.split(':')[1], this.platform.request);
-            accessToken = '';
-        }
-
+        const homeserver = await lookupHomeserver(roomIdOrAlias.split(':')[1], this.platform.request);
         const homeserverApi = new HomeServerApi({
             homeserver: homeserver,
             request: this.platform.request,
-            accessToken: accessToken,
+            accessToken: "",
             reconnector: this.platform.reconnector,
         });
 

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -172,15 +172,24 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
     }
 
     private async _showInitialScreen(shouldRestoreLastUrl: boolean) {
+        if (shouldRestoreLastUrl && this._resolvedSingleRoomId) {
+            // Do not restore last URL to Login if we're in single-room mode.
+            // We do this so that we can try guest login when appropriate.
+            const willShowLogin = this.platform.history.getLastSessionUrl() === "#/login";
+            if (willShowLogin) {
+                shouldRestoreLastUrl = false;
+            }
+        }
+
         if (shouldRestoreLastUrl && this.urlRouter.tryRestoreLastUrl()) {
             // Restored last URL.
             // By the time we get here, _applyNavigation() has run for the restored URL, so we have nothing else
-            // to do here.
+            // to do.
             return;
         }
 
         // We were not able to restore the last URL.
-        // So we send the user to the screen that makes most sense, according to how many sessions they have.
+        // So we send the user to the screen that makes the most sense, according to how many sessions they have.
         const sessionInfos = await this.platform.sessionInfoStorage.getAll();
 
         // Go to Login or, when in single-room mode, try registering guest user.

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -26,7 +26,7 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
     private _unknownRoomViewModel: UnknownRoomViewModel | undefined;
     private _pendingClient: Client;
     private readonly _singleRoomIdOrAlias: string | undefined;
-    private _resolvedSingleRoomId: string | undefined;
+    private _resolvedSingleRoomId: string | null | undefined = undefined;
 
     constructor(options: Options) {
         super(options);
@@ -329,19 +329,19 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
         this.emitChange("activeSection");
     }
 
-    private async getSingleRoomId(): Promise<string|undefined> {
+    private async getSingleRoomId(): Promise<string|null> {
         if (!this._singleRoomIdOrAlias || this._singleRoomIdOrAlias === "") {
-            return undefined;
+            return null;
         }
 
-        if (!this._resolvedSingleRoomId) {
+        if (this._resolvedSingleRoomId === undefined) {
             try {
                 this._resolvedSingleRoomId = await this.resolveRoomAlias(this._singleRoomIdOrAlias);
             } catch (error) {
                 // Something went wrong when resolving the room alias.
                 // We swallow the error and fallback to non-single-room mode.
                 console.warn(error);
-                this._resolvedSingleRoomId = undefined;
+                this._resolvedSingleRoomId = null;
             }
         }
 

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -180,11 +180,15 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
                         return;
                     }
                     this.navigation.push(Section.Login);
-                } else if (sessionInfos.length === 1) {
-                    this.navigation.push(Section.Session, sessionInfos[0].id);
-                } else {
-                    this.navigation.push(Section.Session);
+                    return;
                 }
+
+                if (sessionInfos.length === 1) {
+                    this.navigation.push(Section.Session, sessionInfos[0].id);
+                    return;
+                }
+
+                this.navigation.push(Section.Session);
             } catch (err) {
                 console.error(err);
                 this._setSection(() => this._error = err);

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -163,20 +163,22 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
             }
         } else {
             try {
-                // don't even try to restore last url when in single room mode
-                if (this.singleRoomMode || !(shouldRestoreLastUrl && this.urlRouter.tryRestoreLastUrl())) {
-                    const sessionInfos = await this.platform.sessionInfoStorage.getAll();
-                    if (sessionInfos.length === 0) {
-                        if (this._resolvedSingleRoomId) {
-                            await this._showUnknownRoom(this._resolvedSingleRoomId);
-                            return;
-                        }
-                        this.navigation.push(Section.Login);
-                    } else if (sessionInfos.length === 1) {
-                        this.navigation.push(Section.Session, sessionInfos[0].id);
-                    } else {
-                        this.navigation.push(Section.Session);
+                if (!this._resolvedSingleRoomId && shouldRestoreLastUrl && this.urlRouter.tryRestoreLastUrl()) {
+                    // Restored last URL, nothing else to do.
+                    return;
+                }
+
+                const sessionInfos = await this.platform.sessionInfoStorage.getAll();
+                if (sessionInfos.length === 0) {
+                    if (this._resolvedSingleRoomId) {
+                        await this._showUnknownRoom(this._resolvedSingleRoomId);
+                        return;
                     }
+                    this.navigation.push(Section.Login);
+                } else if (sessionInfos.length === 1) {
+                    this.navigation.push(Section.Session, sessionInfos[0].id);
+                } else {
+                    this.navigation.push(Section.Session);
                 }
             } catch (err) {
                 console.error(err);

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -174,8 +174,8 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
     private async _showInitialScreen(shouldRestoreLastUrl: boolean) {
         const sessionInfos = await this.platform.sessionInfoStorage.getAll();
 
-        // If we're in single-room mode, and we only have a single session, navigate directly to the configured room.
-        if (this._resolvedSingleRoomId && sessionInfos.length === 1) {
+        // If we're in single-room mode, and we have at most one session, navigate directly to the configured room.
+        if (this._resolvedSingleRoomId && sessionInfos.length <= 1) {
             shouldRestoreLastUrl = false;
         }
 

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -172,13 +172,6 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
     }
 
     private async _showInitialScreen(shouldRestoreLastUrl: boolean) {
-        const sessionInfos = await this.platform.sessionInfoStorage.getAll();
-
-        // If we're in single-room mode, and we have at most one session, navigate directly to the configured room.
-        if (this._resolvedSingleRoomId && sessionInfos.length <= 1) {
-            shouldRestoreLastUrl = false;
-        }
-
         if (shouldRestoreLastUrl && this.urlRouter.tryRestoreLastUrl()) {
             // Restored last URL.
             // By the time we get here, _applyNavigation() has run for the restored URL, so we have nothing else
@@ -188,6 +181,7 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
 
         // We were not able to restore the last URL.
         // So we send the user to the screen that makes most sense, according to how many sessions they have.
+        const sessionInfos = await this.platform.sessionInfoStorage.getAll();
 
         // Go to Login or, when in single-room mode, try registering guest user.
         if (sessionInfos.length === 0) {

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -163,7 +163,7 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
             }
         } else {
             try {
-                if (!this._resolvedSingleRoomId && shouldRestoreLastUrl && this.urlRouter.tryRestoreLastUrl()) {
+                if (shouldRestoreLastUrl && this.urlRouter.tryRestoreLastUrl()) {
                     // Restored last URL, nothing else to do.
                     return;
                 }

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -172,11 +172,20 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
     }
 
     private async _showInitialScreen(shouldRestoreLastUrl: boolean) {
+        const sessionInfos = await this.platform.sessionInfoStorage.getAll();
+
         if (shouldRestoreLastUrl && this._resolvedSingleRoomId) {
             // Do not restore last URL to Login if we're in single-room mode.
             // We do this so that we can try guest login when appropriate.
             const willShowLogin = this.platform.history.getLastSessionUrl() === "#/login";
             if (willShowLogin) {
+                shouldRestoreLastUrl = false;
+            }
+
+            // Do not restore last URL to session picker if we're in single-room mode and there are no sessions.
+            // We do this so that we can try guest login in that scenario.
+            const willShowSessionPicker = this.platform.history.getLastSessionUrl() === "#/session";
+            if (shouldRestoreLastUrl && willShowSessionPicker && sessionInfos.length === 0) {
                 shouldRestoreLastUrl = false;
             }
         }
@@ -190,7 +199,6 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
 
         // We were not able to restore the last URL.
         // So we send the user to the screen that makes the most sense, according to how many sessions they have.
-        const sessionInfos = await this.platform.sessionInfoStorage.getAll();
 
         // Go to Login or, when in single-room mode, try registering guest user.
         if (sessionInfos.length === 0) {

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -163,41 +163,44 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
             }
         } else {
             try {
-                if (shouldRestoreLastUrl && this.urlRouter.tryRestoreLastUrl()) {
-                    // Restored last URL.
-                    // By the time we get here, _applyNavigation() has run for the restored URL, so we have nothing else
-                    // to do here.
-                    return;
-                }
-
-                // We were not able to restore the last URL.
-                // So we send the user to the screen that makes most sense, according to how many sessions they have.
-
-                const sessionInfos = await this.platform.sessionInfoStorage.getAll();
-
-                // Send to login or, when in single-room mode, try registering guest user.
-                if (sessionInfos.length === 0) {
-                    if (this._resolvedSingleRoomId) {
-                        await this._showUnknownRoom(this._resolvedSingleRoomId);
-                    } else {
-                        this.navigation.push(Section.Login);
-                    }
-                    return;
-                }
-
-                // Open session.
-                if (sessionInfos.length === 1) {
-                    this.navigation.push(Section.Session, sessionInfos[0].id);
-                    return;
-                }
-
-                // Open session picker.
-                this.navigation.push(Section.Session);
+                await this._showInitialScreen(shouldRestoreLastUrl);
             } catch (err) {
                 console.error(err);
                 this._setSection(() => this._error = err);
             }
         }
+    }
+
+    private async _showInitialScreen(shouldRestoreLastUrl: boolean) {
+        if (shouldRestoreLastUrl && this.urlRouter.tryRestoreLastUrl()) {
+            // Restored last URL.
+            // By the time we get here, _applyNavigation() has run for the restored URL, so we have nothing else
+            // to do here.
+            return;
+        }
+
+        // We were not able to restore the last URL.
+        // So we send the user to the screen that makes most sense, according to how many sessions they have.
+        const sessionInfos = await this.platform.sessionInfoStorage.getAll();
+
+        // Send to login or, when in single-room mode, try registering guest user.
+        if (sessionInfos.length === 0) {
+            if (this._resolvedSingleRoomId) {
+                await this._showUnknownRoom(this._resolvedSingleRoomId);
+            } else {
+                this.navigation.push(Section.Login);
+            }
+            return;
+        }
+
+        // Open session.
+        if (sessionInfos.length === 1) {
+            this.navigation.push(Section.Session, sessionInfos[0].id);
+            return;
+        }
+
+        // Open session picker.
+        this.navigation.push(Section.Session);
     }
 
     private async resolveRoomAlias(roomIdOrAlias: string, sessionId?: string): Promise<string> {

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -172,6 +172,13 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
     }
 
     private async _showInitialScreen(shouldRestoreLastUrl: boolean) {
+        const sessionInfos = await this.platform.sessionInfoStorage.getAll();
+
+        // If we're in single-room mode, and we only have a single session, navigate directly to the configured room.
+        if (this._resolvedSingleRoomId && sessionInfos.length === 1) {
+            shouldRestoreLastUrl = false;
+        }
+
         if (shouldRestoreLastUrl && this.urlRouter.tryRestoreLastUrl()) {
             // Restored last URL.
             // By the time we get here, _applyNavigation() has run for the restored URL, so we have nothing else
@@ -181,8 +188,6 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
 
         // We were not able to restore the last URL.
         // So we send the user to the screen that makes most sense, according to how many sessions they have.
-        const sessionInfos = await this.platform.sessionInfoStorage.getAll();
-
         // Go to Login or, when in single-room mode, try registering guest user.
         if (sessionInfos.length === 0) {
             if (!this._resolvedSingleRoomId) {

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -173,10 +173,11 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
                 shouldRestoreLastUrl = false;
             }
 
-            // Do not restore last URL to session picker if we're in single-room mode and there are no sessions.
-            // We do this so that we can try guest login in that scenario.
+            // Do not restore last URL to session picker if we're in single-room mode and there are zero or one sessions.
+            // We do this so that we can try guest login when there are no sessions, or in the case where there is one
+            // session, use that session.
             const willShowSessionPicker = this.platform.history.getLastSessionUrl() === "#/session";
-            if (shouldRestoreLastUrl && willShowSessionPicker && sessionInfos.length === 0) {
+            if (shouldRestoreLastUrl && willShowSessionPicker && sessionInfos.length <= 1) {
                 shouldRestoreLastUrl = false;
             }
         }

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -113,7 +113,7 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
             try {
                 this._resolvedSingleRoomId = await this.resolveRoomAlias(this._singleRoomIdOrAlias);
             } catch (error) {
-                // Something went wrong when navigating to the room.
+                // Something went wrong when resolving the room alias.
                 // We swallow the error and fallback to non-single-room mode.
                 console.warn(error);
                 this._resolvedSingleRoomId = undefined;
@@ -183,12 +183,20 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
         // So we send the user to the screen that makes most sense, according to how many sessions they have.
         const sessionInfos = await this.platform.sessionInfoStorage.getAll();
 
-        // Send to login or, when in single-room mode, try registering guest user.
+        // Go to Login or, when in single-room mode, try registering guest user.
         if (sessionInfos.length === 0) {
             if (!this._resolvedSingleRoomId) {
                 this.navigation.push(Section.Login);
                 return;
             }
+
+            // Check if homeserver has guest registration enabled.
+            // If not, go to Login.
+            // TODO
+
+            // Check if room is world-readable.
+            // If not, go to Login.
+            // TODO: register guest user.
 
             await this._showUnknownRoom(this._resolvedSingleRoomId);
             return;

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -188,6 +188,7 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
 
         // We were not able to restore the last URL.
         // So we send the user to the screen that makes most sense, according to how many sessions they have.
+
         // Go to Login or, when in single-room mode, try registering guest user.
         if (sessionInfos.length === 0) {
             if (!this._resolvedSingleRoomId) {

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -164,9 +164,14 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
         } else {
             try {
                 if (shouldRestoreLastUrl && this.urlRouter.tryRestoreLastUrl()) {
-                    // Restored last URL, nothing else to do.
+                    // Restored last URL.
+                    // By the time we get here, _applyNavigation() has run for the restored URL, so we have nothing else
+                    // to do here.
                     return;
                 }
+
+                // We were not able to restore the last URL.
+                // So we send the user to the screen that makes most sense, according to how many sessions they have.
 
                 const sessionInfos = await this.platform.sessionInfoStorage.getAll();
                 if (sessionInfos.length === 0) {

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -190,16 +190,19 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
                 return;
             }
 
-            // Check if homeserver has guest registration enabled.
-            // If not, go to Login.
-            // TODO
+            // Attempt to log in as guest. If it fails, go to Login.
+            const homeserver = await lookupHomeserver(this._resolvedSingleRoomId.split(':')[1], this.platform.request);
+            const client = new Client(this.platform);
 
-            // Check if room is world-readable.
-            // If not, go to Login.
-            // TODO: register guest user.
+            await client.doGuestLogin(homeserver);
+            if (client.loadError) {
+                console.warn("Failed to login as guest. Guest registration is probably disabled on the homeserver", client.loadError);
+                this.navigation.push(Section.Login);
+                return;
+            }
 
-            await this._showUnknownRoom(this._resolvedSingleRoomId);
-            return;
+            this._pendingClient = client;
+            this.navigation.push(Section.Session, client.sessionId);
         }
 
         // Open session.

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -174,6 +174,8 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
                 // So we send the user to the screen that makes most sense, according to how many sessions they have.
 
                 const sessionInfos = await this.platform.sessionInfoStorage.getAll();
+
+                // Send to login or, when in single-room mode, try registering guest user.
                 if (sessionInfos.length === 0) {
                     if (this._resolvedSingleRoomId) {
                         await this._showUnknownRoom(this._resolvedSingleRoomId);
@@ -183,11 +185,13 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
                     return;
                 }
 
+                // Open session.
                 if (sessionInfos.length === 1) {
                     this.navigation.push(Section.Session, sessionInfos[0].id);
                     return;
                 }
 
+                // Open session picker.
                 this.navigation.push(Section.Session);
             } catch (err) {
                 console.error(err);

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -179,9 +179,9 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
                 if (sessionInfos.length === 0) {
                     if (this._resolvedSingleRoomId) {
                         await this._showUnknownRoom(this._resolvedSingleRoomId);
-                        return;
+                    } else {
+                        this.navigation.push(Section.Login);
                     }
-                    this.navigation.push(Section.Login);
                     return;
                 }
 

--- a/frontend/iframe/viewmodels/RootViewModel.ts
+++ b/frontend/iframe/viewmodels/RootViewModel.ts
@@ -208,6 +208,7 @@ export class RootViewModel extends ViewModel<SegmentType, Options> {
 
             this._pendingClient = client;
             this.navigation.push(Section.Session, client.sessionId);
+            return;
         }
 
         // Open session.


### PR DESCRIPTION
Fixes #211

This PR fixes several issues with single-room mode and guest login.

Previously we were disabling hydrogen's feature of restoring the last URL, but this breaks hydrogen in subtle ways. So we're no longer doing that globally, instead we only do it for the cases where it makes sense (login and "empty" session picker).

Additionally, we were re-implementing functionality that is already in hydrogen, related to showing the unknown room and checking if it's world-readable. In chatrix we don't need to do this, we just need to login as guest when appropriate, and send the user to the room.

The code that manages which screen is shown under which conditions is hard to understand IMHO (hydrogen is missing a proper "router"), so I refactored it a bit and added a bunch of comments.

I tested this in all the ways I could think of and did not find any issues. However, there are unrelated issues that can look like it's an issue with this PR (#224 and #225) so take that in mind if you do testing on your side.

## TODO

- [x] When there's a single session in the session picker, and we're in single-room mode, it doesn't go directly into that session, and instead shows the session picker