### PR TITLE
Release 0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - Tested up to: 6.2
 - Requires PHP: 7.4
 - License: [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html)
-- Stable tag: 0.8.3
+- Stable tag: 0.9.0
 - GitHub Plugin URI: https://github.com/Automattic/chatrix
 
 Matrix client for WordPress.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Later, when Matrix makes the switch to OIDC, you are already prepared and can co
 
 ## Changelog
 
+### 0.9.0
+
+- Chatrix is now a single-session client. The session picker is no longer displayed [[#239](https://github.com/Automattic/chatrix/pull/239)]. This fixes [#236](https://github.com/Automattic/chatrix/issues/236) [#224](https://github.com/Automattic/chatrix/issues/224) [#200](https://github.com/Automattic/chatrix/issues/200).
+
 ### 0.8.3
 
 - Improve the view for rooms that are you not a member of (Upgraded our Hydrogen's fork to [latest](https://github.com/Automattic/hydrogen-web/compare/chatrix-0.8.0...Automattic:hydrogen-web:chatrix-0.8.3))

--- a/chatrix.php
+++ b/chatrix.php
@@ -5,7 +5,7 @@
  * Author: WordPress.Org Community
  * Author URI: https://wordpress.org/
  * Plugin URI: https://github.com/Automattic/chatrix
- * Version: 0.8.3
+ * Version: 0.9.0
  */
 
 use function Automattic\Chatrix\Admin\main as adminMain;
@@ -22,7 +22,7 @@ function automattic_chatrix_version(): string {
 	}
 
 	// Do not edit this line, it's automatically set by bin/prepare-release.sh.
-	$version = '0.8.3';
+	$version = '0.9.0';
 
 	return $version;
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/chatrix",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "WordPress plugin to embed a Matrix client into WordPress pages.",
   "type": "wordpress-plugin",
   "license": "GPL",

--- a/frontend/block/block.json
+++ b/frontend/block/block.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "apiVersion": 2,
   "name": "automattic/chatrix",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "title": "Chatrix",
   "category": "embed",
   "icon": "format-chat",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatrix",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Embedded Matrix client for WordPress",
   "repository": "git@github.com:Automattic/chatrix.git",
   "author": "Automattic",


### PR DESCRIPTION
[Commits since 0.8.3](https://github.com/Automattic/chatrix/compare/0.8.3...release-0.9.0)

## Changelog

- Chatrix is now a single-session client. The session picker is no longer displayed [[#239](https://github.com/Automattic/chatrix/pull/239)]. This fixes [#236](https://github.com/Automattic/chatrix/issues/236) [#224](https://github.com/Automattic/chatrix/issues/224) [#200](https://github.com/Automattic/chatrix/issues/200).