### PR TITLE
Don't enqueue scripts in embeds

### DIFF
--- a/src/plugin.php
+++ b/src/plugin.php
@@ -21,7 +21,7 @@ function main() {
 
 function register_scripts() {
 	add_action(
-		'init',
+		'wp_enqueue_scripts',
 		function () {
 			$json_data = wp_json_encode(
 				array(


### PR DESCRIPTION
Fixes #247.

We don't need to register and enqueue our scripts at `init`, it's enough at `wp_enqueue_scripts`. A side-effect is that this won't be enqueued in embeds as reported in #247.