### PR TITLE
Release 0.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - Tested up to: 6.8
 - Requires PHP: 7.4
 - License: [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html)
-- Stable tag: 0.9.1
+- Stable tag: 0.9.2
 - GitHub Plugin URI: https://github.com/Automattic/chatrix
 
 Matrix client for WordPress.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Later, when Matrix makes the switch to OIDC, you are already prepared and can co
 
 ## Changelog
 
+### 0.9.2
+- Fix Chatrix iframe not loading in Gutenberg editor [#256](https://github.com/Automattic/chatrix/pull/256)
+
 ### 0.9.1
 - We now don't enqueue scripts in embeds [#249](https://github.com/Automattic/chatrix/pull/249)
 - It is now possible to disable service worker at runtime [#243](https://github.com/Automattic/chatrix/pull/243)

--- a/chatrix.php
+++ b/chatrix.php
@@ -5,7 +5,7 @@
  * Author: WordPress.Org Community
  * Author URI: https://wordpress.org/
  * Plugin URI: https://github.com/Automattic/chatrix
- * Version: 0.9.1
+ * Version: 0.9.2
  */
 
 use function Automattic\Chatrix\Admin\main as adminMain;
@@ -22,7 +22,7 @@ function automattic_chatrix_version(): string {
 	}
 
 	// Do not edit this line, it's automatically set by bin/prepare-release.sh.
-	$version = '0.9.1';
+	$version = '0.9.2';
 
 	return $version;
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/chatrix",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "WordPress plugin to embed a Matrix client into WordPress pages.",
   "type": "wordpress-plugin",
   "license": "GPL",

--- a/frontend/block/block.json
+++ b/frontend/block/block.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "apiVersion": 2,
   "name": "automattic/chatrix",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "title": "Chatrix",
   "category": "embed",
   "icon": "format-chat",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatrix",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Embedded Matrix client for WordPress",
   "repository": "git@github.com:Automattic/chatrix.git",
   "author": "Automattic",


### PR DESCRIPTION
[Commits since 0.9.1](https://github.com/Automattic/chatrix/compare/0.9.1...release-0.9.2)

## Changelog:

- Fix Chatrix iframe not loading in Gutenberg editor [#256](https://github.com/Automattic/chatrix/pull/256)